### PR TITLE
Refactor

### DIFF
--- a/src/components/EQ3Controls.tsx
+++ b/src/components/EQ3Controls.tsx
@@ -1,39 +1,55 @@
-import { useCallback, memo } from "react";
+import { useState, useCallback, memo } from "react";
 import Knob from "./Knob";
 import { EQ3ControlsProps } from "../types";
 import "../styles/EQ3Controls.css";
 
-const EQ3Controls = ({ eq3Options, setEQ3Option }: EQ3ControlsProps) => {
+const EQ3Controls = ({ eq3 }: EQ3ControlsProps) => {
+  const [low, setLow] = useState(eq3.low.value);
+  const [mid, setMid] = useState(eq3.mid.value);
+  const [high, setHigh] = useState(eq3.high.value);
+  const [lowFreq, setLowFreq] = useState(eq3.lowFrequency.value as number);
+  const [highFreq, setHighFreq] = useState(eq3.highFrequency.value as number);
+
   const handleLowChange = useCallback(
     (value: number) => {
-      setEQ3Option(value, "low");
+      eq3.set({ low: value });
+      setLow(value);
     },
-    [setEQ3Option]
+    [eq3]
   );
+
   const handleMidChange = useCallback(
     (value: number) => {
-      setEQ3Option(value, "mid");
+      eq3.set({ mid: value });
+      setMid(value);
     },
-    [setEQ3Option]
+    [eq3]
   );
+
   const handleHighChange = useCallback(
     (value: number) => {
-      setEQ3Option(value, "high");
+      eq3.set({ high: value });
+      setHigh(value);
     },
-    [setEQ3Option]
+    [eq3]
   );
-  const handleLowFrequencyChange = useCallback(
+
+  const handleLowFreqChange = useCallback(
     (value: number) => {
-      setEQ3Option(value, "lowFrequency");
+      eq3.set({ lowFrequency: value });
+      setLowFreq(value);
     },
-    [setEQ3Option]
+    [eq3]
   );
-  const handleHighFrequencyChange = useCallback(
+
+  const handleHighFreqChange = useCallback(
     (value: number) => {
-      setEQ3Option(value, "highFrequency");
+      eq3.set({ highFrequency: value });
+      setHighFreq(value);
     },
-    [setEQ3Option]
+    [eq3]
   );
+
   return (
     <div className="control-container EQ3-container">
       <div className="row justify-center">
@@ -46,7 +62,7 @@ const EQ3Controls = ({ eq3Options, setEQ3Option }: EQ3ControlsProps) => {
           <Knob
             min={-60}
             max={6}
-            value={eq3Options.low}
+            value={low}
             onValueChange={handleLowChange}
             width={50}
             height={50}
@@ -54,14 +70,14 @@ const EQ3Controls = ({ eq3Options, setEQ3Option }: EQ3ControlsProps) => {
           />
           <label className="unselectable title-small">Low</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            eq3Options.low
+            low
           )}db`}</span>
         </div>
         <div className="column hasTooltip">
           <Knob
             min={-60}
             max={6}
-            value={eq3Options.mid}
+            value={mid}
             onValueChange={handleMidChange}
             width={50}
             height={50}
@@ -69,14 +85,14 @@ const EQ3Controls = ({ eq3Options, setEQ3Option }: EQ3ControlsProps) => {
           />
           <label className="unselectable title-small">Mid</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            eq3Options.mid
+            mid
           )}db`}</span>
         </div>
         <div className="column hasTooltip">
           <Knob
             min={-60}
             max={6}
-            value={eq3Options.high}
+            value={high}
             onValueChange={handleHighChange}
             width={50}
             height={50}
@@ -84,7 +100,7 @@ const EQ3Controls = ({ eq3Options, setEQ3Option }: EQ3ControlsProps) => {
           />
           <label className="unselectable title-small">High</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            eq3Options.high
+            high
           )}db`}</span>
         </div>
       </div>
@@ -93,30 +109,30 @@ const EQ3Controls = ({ eq3Options, setEQ3Option }: EQ3ControlsProps) => {
           <Knob
             min={50}
             max={5000}
-            value={eq3Options.lowFrequency}
-            onValueChange={handleLowFrequencyChange}
+            value={lowFreq}
+            onValueChange={handleLowFreqChange}
             width={50}
             height={50}
             step={1}
           />
           <label className="unselectable title-small">FreqLow</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            eq3Options.lowFrequency
+            lowFreq
           )}hz`}</span>
         </div>
         <div className="column eq-freq-knob hasTooltip">
           <Knob
             min={200}
             max={18000}
-            value={eq3Options.highFrequency}
-            onValueChange={handleHighFrequencyChange}
+            value={highFreq}
+            onValueChange={handleHighFreqChange}
             width={50}
             height={50}
             step={1}
           />
           <label className="unselectable title-small">FreqHigh</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            eq3Options.highFrequency
+            highFreq
           )}hz`}</span>
         </div>
       </div>

--- a/src/components/EffectsControls.tsx
+++ b/src/components/EffectsControls.tsx
@@ -1,72 +1,98 @@
-import { useCallback, memo } from "react";
+import { useCallback, useState, memo } from "react";
 import Knob from "./Knob";
 import { EffectsControlsProps } from "../types";
 import "../styles/EffectsControls.css";
 
 const EffectsControls = ({
-  reverbOptions,
-  distortionOptions,
-  delayOptions,
-  bitCrusherOptions,
-  setReverbOption,
-  setDistortionOption,
-  setDelayOption,
-  setBitCrusherOption,
+  reverb,
+  distortion,
+  delay,
+  bitCrusher,
 }: EffectsControlsProps) => {
+  const [delayWet, setDelayWet] = useState(delay.get().wet);
+  const [delayTime, setDelayTime] = useState(Number(delay.get().delayTime));
+  const [delayFeedback, setDelayFeedback] = useState(delay.get().feedback);
+  const [reverbWet, setReverbWet] = useState(reverb.get().wet);
+  const [reverbDecay, setReverbDecay] = useState(reverb.get().decay);
+  const [distortionWet, setDistortionWet] = useState(distortion.get().wet);
+  const [distortionAmount, setDistortionAmount] = useState(
+    distortion.get().distortion
+  );
+  const [bitCrusherWet, setBitCrusherWet] = useState(bitCrusher.get().wet);
+  const [bitCrusherBits, setBitCrusherBits] = useState(bitCrusher.get().bits);
+
   const handleDelayWetChange = useCallback(
     (value: number) => {
-      setDelayOption(value, "wet");
+      delay.set({ wet: value });
+      setDelayWet(value);
     },
-    [setDelayOption]
+    [delay]
   );
+
   const handleDelayTimeChange = useCallback(
     (value: number) => {
-      setDelayOption(value, "delayTime");
+      delay.set({ delayTime: value });
+      setDelayTime(value);
     },
-    [setDelayOption]
+    [delay]
   );
+
   const handleDelayFeedbackChange = useCallback(
     (value: number) => {
-      setDelayOption(value, "feedback");
+      delay.set({ feedback: value });
+      setDelayFeedback(value);
     },
-    [setDelayOption]
+    [delay]
   );
+
   const handleReverbWetChange = useCallback(
     (value: number) => {
-      setReverbOption(value, "wet");
+      reverb.set({ wet: value });
+      setReverbWet(value);
     },
-    [setReverbOption]
+    [reverb]
   );
+
   const handleReverbDecayChange = useCallback(
     (value: number) => {
-      setReverbOption(value, "decay");
+      reverb.set({ decay: value });
+      setReverbDecay(value);
     },
-    [setReverbOption]
+    [reverb]
   );
+
   const handleDistortionWetChange = useCallback(
     (value: number) => {
-      setDistortionOption(value, "wet");
+      distortion.set({ wet: value });
+      setDistortionWet(value);
     },
-    [setDistortionOption]
+    [distortion]
   );
+
   const handleDistortionChange = useCallback(
     (value: number) => {
-      setDistortionOption(value, "distortion");
+      distortion.set({ distortion: value });
+      setDistortionAmount(value);
     },
-    [setDistortionOption]
+    [distortion]
   );
+
   const handleBitCrusherWetChange = useCallback(
     (value: number) => {
-      setBitCrusherOption(value, "wet");
+      bitCrusher.set({ wet: value });
+      setBitCrusherWet(value);
     },
-    [setBitCrusherOption]
+    [bitCrusher]
   );
+
   const handleBitCrusherBitsChange = useCallback(
     (value: number) => {
-      setBitCrusherOption(value, "bits");
+      bitCrusher.set({ bits: value });
+      setBitCrusherBits(value);
     },
-    [setBitCrusherOption]
+    [bitCrusher]
   );
+
   return (
     <div className="control-container effects-container">
       <div className="row justify-center">
@@ -82,7 +108,7 @@ const EffectsControls = ({
               <Knob
                 min={0}
                 max={1}
-                value={delayOptions.wet}
+                value={delayWet}
                 onValueChange={handleDelayWetChange}
                 width={45.5}
                 height={45.5}
@@ -90,14 +116,14 @@ const EffectsControls = ({
               />
               <label className="unselectable title-small">Wet</label>
               <span className="tooltip unselectable value">{`${(
-                delayOptions.wet * 100
+                delayWet * 100
               ).toFixed(0)}%`}</span>
             </div>
             <div className="column hasTooltip">
               <Knob
                 min={0}
                 max={1}
-                value={delayOptions.delayTime}
+                value={delayTime}
                 onValueChange={handleDelayTimeChange}
                 width={45.5}
                 height={45.5}
@@ -105,7 +131,7 @@ const EffectsControls = ({
               />
               <label className="unselectable title-small">Time</label>
               <span className="tooltip unselectable value">{`${Math.round(
-                delayOptions.delayTime * 1000
+                delayTime * 1000
               )}ms`}</span>
             </div>
           </div>
@@ -114,7 +140,7 @@ const EffectsControls = ({
               <Knob
                 min={0}
                 max={1}
-                value={delayOptions.feedback}
+                value={delayFeedback}
                 onValueChange={handleDelayFeedbackChange}
                 width={45.5}
                 height={45.5}
@@ -122,7 +148,7 @@ const EffectsControls = ({
               />
               <label className="unselectable title-small">Feedbk</label>
               <span className="tooltip unselectable value">{`${(
-                delayOptions.feedback * 100
+                delayFeedback * 100
               ).toFixed(0)}%`}</span>
             </div>
           </div>
@@ -134,7 +160,7 @@ const EffectsControls = ({
               <Knob
                 min={0}
                 max={1}
-                value={bitCrusherOptions.wet}
+                value={bitCrusherWet}
                 onValueChange={handleBitCrusherWetChange}
                 width={45.5}
                 height={45.5}
@@ -142,7 +168,7 @@ const EffectsControls = ({
               />
               <label className="unselectable title-small">Wet</label>
               <span className="tooltip unselectable value">{`${(
-                bitCrusherOptions.wet * 100
+                bitCrusherWet * 100
               ).toFixed(0)}%`}</span>
             </div>
           </div>
@@ -151,7 +177,7 @@ const EffectsControls = ({
               <Knob
                 min={1}
                 max={16}
-                value={bitCrusherOptions.bits}
+                value={bitCrusherBits}
                 onValueChange={handleBitCrusherBitsChange}
                 width={45.5}
                 height={45.5}
@@ -159,7 +185,7 @@ const EffectsControls = ({
               />
               <label className="unselectable title-small">Bits</label>
               <span className="tooltip unselectable value">{`${Math.round(
-                bitCrusherOptions.bits
+                bitCrusherBits
               )}`}</span>
             </div>
           </div>
@@ -171,7 +197,7 @@ const EffectsControls = ({
               <Knob
                 min={0}
                 max={1}
-                value={distortionOptions.wet}
+                value={distortionWet}
                 onValueChange={handleDistortionWetChange}
                 width={45.5}
                 height={45.5}
@@ -179,7 +205,7 @@ const EffectsControls = ({
               />
               <label className="unselectable title-small">Wet</label>
               <span className="tooltip unselectable value">{`${(
-                distortionOptions.wet * 100
+                distortionWet * 100
               ).toFixed(0)}%`}</span>
             </div>
           </div>
@@ -188,7 +214,7 @@ const EffectsControls = ({
               <Knob
                 min={0}
                 max={1}
-                value={distortionOptions.distortion}
+                value={distortionAmount}
                 onValueChange={handleDistortionChange}
                 width={45.5}
                 height={45.5}
@@ -196,7 +222,7 @@ const EffectsControls = ({
               />
               <label className="unselectable title-small">Amount</label>
               <span className="tooltip unselectable value">{`${(
-                distortionOptions.distortion * 100
+                distortionAmount * 100
               ).toFixed(0)}%`}</span>
             </div>
           </div>
@@ -207,7 +233,7 @@ const EffectsControls = ({
             <Knob
               min={0}
               max={1}
-              value={reverbOptions.wet}
+              value={reverbWet}
               onValueChange={handleReverbWetChange}
               width={45.5}
               height={45.5}
@@ -215,14 +241,14 @@ const EffectsControls = ({
             />
             <label className="unselectable title-small">Wet</label>
             <span className="tooltip unselectable value">{`${(
-              reverbOptions.wet * 100
+              reverbWet * 100
             ).toFixed(0)}%`}</span>
           </div>
           <div className="column hasTooltip">
             <Knob
               min={1}
               max={30}
-              value={reverbOptions.decay}
+              value={reverbDecay}
               onValueChange={handleReverbDecayChange}
               width={45.5}
               height={45.5}
@@ -230,7 +256,7 @@ const EffectsControls = ({
             />
             <label className="unselectable title-small">Decay</label>
             <span className="tooltip unselectable value">{`${Math.round(
-              reverbOptions.decay
+              reverbDecay
             )}`}</span>
           </div>
         </div>

--- a/src/components/EnvelopeControls.tsx
+++ b/src/components/EnvelopeControls.tsx
@@ -1,35 +1,49 @@
-import { useCallback, memo } from "react";
+import { useCallback, useState, memo } from "react";
 import Slider from "./Slider";
 import { EnvelopeControlsProps } from "../types";
 
-const EnvelopeControls = ({
-  envelopeOptions,
-  setEnvelopeOption,
-}: EnvelopeControlsProps) => {
+const EnvelopeControls = ({ synth1, synth2 }: EnvelopeControlsProps) => {
+  const [attack, setAttack] = useState(Number(synth1.get().envelope.attack));
+  const [decay, setDecay] = useState(Number(synth1.get().envelope.decay));
+  const [sustain, setSustain] = useState(synth1.get().envelope.sustain);
+  const [release, setRelease] = useState(Number(synth1.get().envelope.release));
+
   const handleAttackChange = useCallback(
     (value) => {
-      setEnvelopeOption(value, "attack");
+      synth1.set({ envelope: { attack: value } });
+      synth2.set({ envelope: { attack: value } });
+      setAttack(value);
     },
-    [setEnvelopeOption]
+    [synth1, synth2]
   );
+
   const handleDecayChange = useCallback(
     (value) => {
-      setEnvelopeOption(value, "decay");
+      synth1.set({ envelope: { decay: value } });
+      synth2.set({ envelope: { decay: value } });
+      setDecay(value);
     },
-    [setEnvelopeOption]
+    [synth1, synth2]
   );
+
   const handleSustainChange = useCallback(
     (value) => {
-      setEnvelopeOption(value, "sustain");
+      synth1.set({ envelope: { sustain: value } });
+      synth2.set({ envelope: { sustain: value } });
+      setSustain(value);
     },
-    [setEnvelopeOption]
+    [synth1, synth2]
   );
+
   const handleReleaseChange = useCallback(
     (value) => {
-      setEnvelopeOption(value, "release");
+      synth1.set({ envelope: { release: value } });
+      synth2.set({ envelope: { release: value } });
+      setRelease(value);
     },
-    [setEnvelopeOption]
+    [synth1, synth2]
   );
+
   return (
     <div className="control-container envelope-container">
       <div className="row justify-center">
@@ -45,13 +59,13 @@ const EnvelopeControls = ({
             step={0.01}
             width={50}
             height={96}
-            value={Number(envelopeOptions.attack)}
+            value={attack}
             onValueChange={handleAttackChange}
           />
           <label className="unselectable title-small">ATK</label>
-          <span className="tooltip unselectable value">{`${Number(
-            parseFloat(envelopeOptions.attack.toString()).toFixed(3)
-          )}`}</span>
+          <span className="tooltip unselectable value">
+            {attack.toFixed(3)}
+          </span>
         </div>
         <div className="column hasTooltip">
           <Slider
@@ -60,13 +74,11 @@ const EnvelopeControls = ({
             step={0.01}
             width={50}
             height={96}
-            value={Number(envelopeOptions.decay)}
+            value={decay}
             onValueChange={handleDecayChange}
           />
           <label className="unselectable title-small">DEC</label>
-          <span className="tooltip unselectable value">{`${Number(
-            parseFloat(envelopeOptions.decay.toString()).toFixed(3)
-          )}`}</span>
+          <span className="tooltip unselectable value">{decay.toFixed(3)}</span>
         </div>
         <div className="column hasTooltip">
           <Slider
@@ -75,13 +87,13 @@ const EnvelopeControls = ({
             step={0.01}
             width={50}
             height={96}
-            value={Number(envelopeOptions.sustain)}
+            value={sustain}
             onValueChange={handleSustainChange}
           />
           <label className="unselectable title-small">SUS</label>
-          <span className="tooltip unselectable value">{`${Number(
-            parseFloat(envelopeOptions.sustain.toString()).toFixed(3)
-          )}`}</span>
+          <span className="tooltip unselectable value">
+            {sustain.toFixed(3)}
+          </span>
         </div>
         <div className="column hasTooltip">
           <Slider
@@ -90,13 +102,13 @@ const EnvelopeControls = ({
             step={0.01}
             width={50}
             height={96}
-            value={Number(envelopeOptions.release)}
+            value={release}
             onValueChange={handleReleaseChange}
           />
           <label className="unselectable title-small">REL</label>
-          <span className="tooltip unselectable value">{`${Number(
-            parseFloat(envelopeOptions.release.toString()).toFixed(3)
-          )}`}</span>
+          <span className="tooltip unselectable value">
+            {release.toFixed(3)}
+          </span>
         </div>
       </div>
     </div>

--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -59,26 +59,24 @@ const FilterControls = ({
         </div>
       </div>
       <div className="column">
-        <div className="row filter-type-buttons">
+        <div className="row type-buttons">
           <RadioButtonGroup
             items={FILTER_TYPES}
             id={"filter types"}
             comparator={filterOptions.type}
-            buttonWidth={28}
-            buttonHeight={28}
+            buttonSize="large"
             onValueChange={handleFilterTypeChange}
           />
         </div>
       </div>
       <div className="row justify-between">
         <div className="column">
-          <div style={{ display: "grid", gridTemplateColumns: `36px 36px` }}>
+          <div className="rolloff-buttons">
             <RadioButtonGroup
               items={ROLLOFFS}
               id={"filter rolloffs"}
               comparator={filterOptions.rolloff.toString()}
-              buttonWidth={26}
-              buttonHeight={12}
+              buttonSize="small"
               onValueChange={handleFilterRolloffChange}
             />
           </div>

--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -1,47 +1,63 @@
-import { useCallback, memo, ChangeEvent } from "react";
+import { useCallback, useState, memo, ChangeEvent } from "react";
 import FilterDisplay from "./FilterDisplay";
 import Knob from "./Knob";
 import RadioButtonGroup from "./RadioButtonGroup";
 import { FILTER_TYPES, ROLLOFFS } from "../globals/constants";
 import { FilterControlsProps } from "../types";
 import "../styles/FilterControls.css";
+import { FilterRollOff } from "tone";
 
-const FilterControls = ({
-  filterOptions,
-  setFilterOption,
-  isPlaying,
-  fft,
-}: FilterControlsProps) => {
+const FilterControls = ({ filter, isPlaying, fft }: FilterControlsProps) => {
+  const [type, setType] = useState(filter.type);
+  const [rolloff, setRolloff] = useState(filter.rolloff);
+  const [q, setQ] = useState(filter.get().Q);
+  const [freq, setFreq] = useState(
+    filter.frequency.toFrequency(filter.frequency.value)
+  );
+  const [gain, setGain] = useState(filter.get().gain);
+
   const handleFilterTypeChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      setFilterOption(e.target.value as BiquadFilterType, "type");
+      const value = e.target.value as BiquadFilterType;
+      filter.set({ type: value });
+      setType(value);
     },
-    [setFilterOption]
+    [filter]
   );
+
   const handleFilterRolloffChange = useCallback(
-    (e: any) => {
-      setFilterOption(e.target.value, "rolloff");
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const value = Number(e.target.value) as FilterRollOff;
+      filter.set({ rolloff: value });
+      setRolloff(value);
     },
-    [setFilterOption]
+    [filter]
   );
+
   const handleFilterQChange = useCallback(
     (value: number) => {
-      setFilterOption(value, "Q");
+      filter.set({ Q: value });
+      setQ(value);
     },
-    [setFilterOption]
+    [filter]
   );
+
   const handleFilterFrequencyChange = useCallback(
     (value: number) => {
-      setFilterOption(value, "frequency");
+      filter.set({ frequency: value });
+      setFreq(value);
     },
-    [setFilterOption]
+    [filter]
   );
+
   const handleFilterGainChange = useCallback(
     (value: number) => {
-      setFilterOption(value, "gain");
+      filter.set({ gain: value });
+      setGain(value);
     },
-    [setFilterOption]
+    [filter]
   );
+
   return (
     <div className="control-container filter-container">
       <div className="row justify-center">
@@ -52,7 +68,11 @@ const FilterControls = ({
       <div className="column">
         <div className="row">
           <FilterDisplay
-            filterOptions={filterOptions}
+            type={type}
+            rolloff={rolloff}
+            q={q}
+            freq={freq}
+            gain={gain}
             isPlaying={isPlaying}
             fft={fft}
           />
@@ -63,7 +83,7 @@ const FilterControls = ({
           <RadioButtonGroup
             items={FILTER_TYPES}
             id={"filter types"}
-            comparator={filterOptions.type}
+            comparator={type}
             buttonSize="large"
             onValueChange={handleFilterTypeChange}
           />
@@ -75,7 +95,7 @@ const FilterControls = ({
             <RadioButtonGroup
               items={ROLLOFFS}
               id={"filter rolloffs"}
-              comparator={filterOptions.rolloff.toString()}
+              comparator={rolloff.toString()}
               buttonSize="small"
               onValueChange={handleFilterRolloffChange}
             />
@@ -84,7 +104,7 @@ const FilterControls = ({
         </div>
         <div className="column filter-knob hasTooltip">
           <Knob
-            value={filterOptions.Q}
+            value={q}
             width={50}
             height={50}
             onValueChange={handleFilterQChange}
@@ -94,12 +114,12 @@ const FilterControls = ({
           />
           <label className="unselectable title-small">Res</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            filterOptions.Q as number
+            q
           )}`}</span>
         </div>
         <div className="column filter-knob hasTooltip">
           <Knob
-            value={filterOptions.frequency}
+            value={freq}
             width={50}
             height={50}
             onValueChange={handleFilterFrequencyChange}
@@ -109,12 +129,12 @@ const FilterControls = ({
           />
           <label className="unselectable title-small">Cutoff</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            filterOptions.frequency
+            freq
           )}Hz`}</span>
         </div>
         <div className="column filter-knob hasTooltip">
           <Knob
-            value={filterOptions.gain}
+            value={gain}
             width={50}
             height={50}
             onValueChange={handleFilterGainChange}
@@ -124,7 +144,7 @@ const FilterControls = ({
           />
           <label className="unselectable title-small">Gain</label>
           <span className="tooltip unselectable value">{`${Math.round(
-            filterOptions.gain
+            gain
           )}`}</span>
         </div>
       </div>

--- a/src/components/Key.tsx
+++ b/src/components/Key.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef } from "react";
+import { memo, MouseEvent, TouchEvent } from "react";
 import { KeyProps } from "../types";
 import { keyIsPressed, keyIsSharp } from "../utils";
 import "../styles/Key.css";
@@ -11,7 +11,13 @@ const Key = ({ note, octave, notesPlaying, playNote, stopNote }: KeyProps) => {
   if (isSharp) keyClassName += " sharp";
   if (isPressed) keyClassName += " pressed";
 
-  const key = useRef<HTMLDivElement>(null);
+  const handleMouseDown = (event: MouseEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (!isPressed) {
+      const fullNote = note + octave;
+      playNote(fullNote, true);
+    }
+  };
 
   const handleMouseUp = () => {
     if (isPressed) {
@@ -34,51 +40,29 @@ const Key = ({ note, octave, notesPlaying, playNote, stopNote }: KeyProps) => {
     }
   };
 
-  useEffect(() => {
-    const handleMouseDown = (event: MouseEvent) => {
-      event.preventDefault();
-      if (!isPressed) {
-        const fullNote = note + octave;
-        playNote(fullNote, true);
-      }
-    };
+  const handleTouchStart = () => {
+    const fullNote = note + octave;
+    playNote(fullNote, true);
+  };
 
-    const handleTouchStart = (event: TouchEvent) => {
-      event.preventDefault();
+  const handleTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    if (isPressed) {
       const fullNote = note + octave;
-      playNote(fullNote, true);
-    };
-
-    const handleTouchEnd = (event: TouchEvent) => {
-      event.preventDefault();
-      if (isPressed) {
-        const fullNote = note + octave;
-        stopNote(fullNote, true);
-      }
-    };
-    if (key) {
-      const current = key.current;
-      if (current) {
-        current.addEventListener("mousedown", handleMouseDown);
-        current.addEventListener("touchstart", handleTouchStart);
-        current.addEventListener("touchend", handleTouchEnd);
-
-        return () => {
-          current.removeEventListener("mousedown", handleMouseDown);
-          current.removeEventListener("touchstart", handleTouchStart);
-          current.removeEventListener("touchend", handleTouchEnd);
-        };
-      }
+      stopNote(fullNote, true);
     }
-  }, [isPressed, note, octave, playNote, stopNote]);
+  };
 
   return (
     <div
-      ref={key}
+      // ref={key}
       className={keyClassName}
+      onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseLeave}
       onMouseEnter={handleMouseEnter}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
     />
   );
 };

--- a/src/components/Key.tsx
+++ b/src/components/Key.tsx
@@ -55,7 +55,6 @@ const Key = ({ note, octave, notesPlaying, playNote, stopNote }: KeyProps) => {
 
   return (
     <div
-      // ref={key}
       className={keyClassName}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}

--- a/src/components/KeyboardOctave.tsx
+++ b/src/components/KeyboardOctave.tsx
@@ -10,10 +10,10 @@ const KeyboardOctave = ({
   stopNote,
 }: KeyboardProps) => {
   const createKeys = () => {
-    return NOTES.map((note, i) => {
+    return NOTES.map((note) => {
       return (
         <Key
-          key={`${note}${octave}${i}`}
+          key={`${note}${octave}`}
           note={note}
           octave={octave}
           notesPlaying={notesPlaying}

--- a/src/components/MasterControls.tsx
+++ b/src/components/MasterControls.tsx
@@ -1,21 +1,24 @@
-import { useCallback, memo } from "react";
+import { useCallback, memo, useState } from "react";
 import Knob from "./Knob";
 import { MasterControlsProps } from "../types";
 import { left, right } from "../icons";
 import "../styles/MasterControls.css";
 
 const MasterControls = ({
+  masterVolume,
   octave,
-  volume,
   setOctave,
-  setVolume,
 }: MasterControlsProps) => {
+  const [volume, setVolume] = useState(masterVolume.volume.value);
+
   const handleVolumeChange = useCallback(
-    (value) => {
+    (value: number) => {
+      masterVolume.set({ volume: value });
       setVolume(value);
     },
-    [setVolume]
+    [masterVolume]
   );
+
   return (
     <div className="master-controls-container">
       <div className="column hasTooltip">

--- a/src/components/Midi.tsx
+++ b/src/components/Midi.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect, ChangeEvent } from "react";
 import { Input, WebMidi } from "webmidi";
 import { MidiProps } from "../types";
 import "../styles/Midi.css";
@@ -36,9 +36,9 @@ const Midi = ({ playNote, stopNote }: MidiProps) => {
     }
   }, [selectedMidi, playNote, stopNote]);
 
-  const handleSelect = (name: string) => {
+  const handleSelect = (event: ChangeEvent<HTMLSelectElement>) => {
     if (selectedMidi) selectedMidi.removeListener();
-    setSelectedMidi(WebMidi.getInputByName(name));
+    setSelectedMidi(WebMidi.getInputByName(event.target.value));
   };
 
   return (
@@ -48,12 +48,14 @@ const Midi = ({ playNote, stopNote }: MidiProps) => {
           selectedMidi?.connection ? "green" : "red"
         }`}
       />
-      <label htmlFor="midiSelect">MIDI</label>
+      <label className="unselectable" htmlFor="midiSelect">
+        MIDI
+      </label>
       <select
-        className="midi-select"
+        className="midi-select unselectable"
         name="midiSelect"
         onClick={findMidi}
-        onChange={(event) => handleSelect(event.target.value)}
+        onChange={handleSelect}
       >
         <option value="">None</option>
         {inputs.map((input) => {

--- a/src/components/OscillatorControls.tsx
+++ b/src/components/OscillatorControls.tsx
@@ -1,41 +1,46 @@
-import { useCallback, memo, ChangeEvent } from "react";
+import { useCallback, useState, memo, ChangeEvent } from "react";
 import Knob from "./Knob";
 import RadioButtonGroup from "./RadioButtonGroup";
 import { WAVEFORMS } from "../globals/constants";
 import { OscillatorControlsProps } from "../types";
 
-const OscillatorControls = ({
-  synthNum,
-  synthOptions,
-  setSynthOption,
-}: OscillatorControlsProps) => {
+const OscillatorControls = ({ synthNum, synth }: OscillatorControlsProps) => {
+  const [type, setType] = useState(synth.get().oscillator.type);
+  const [volume, setVolume] = useState(synth.get().volume);
+  const [phase, setPhase] = useState(synth.get().oscillator.phase);
+  const [detune, setDetune] = useState(synth.get().detune);
+
   const handleTypeChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
-      console.log(e);
-      setSynthOption(e.target.value as OscillatorType, "type", synthNum);
+      const value = e.target.value as OscillatorType;
+      synth.set({ oscillator: { type: value } });
+      setType(value);
     },
-    [setSynthOption, synthNum]
+    [synth]
   );
 
-  const handleVolumechange = useCallback(
+  const handleVolumeChange = useCallback(
     (value: number) => {
-      setSynthOption(value, "volume", synthNum);
+      synth.set({ volume: value });
+      setVolume(value);
     },
-    [setSynthOption, synthNum]
+    [synth]
   );
 
   const handlePhaseChange = useCallback(
     (value: number) => {
-      setSynthOption(value, "phase", synthNum);
+      synth.set({ oscillator: { phase: value } });
+      setPhase(value);
     },
-    [setSynthOption, synthNum]
+    [synth]
   );
 
   const handleDetuneChange = useCallback(
     (value: number) => {
-      setSynthOption(value, "detune", synthNum);
+      synth.set({ detune: value });
+      setDetune(value);
     },
-    [setSynthOption, synthNum]
+    [synth]
   );
 
   return (
@@ -51,7 +56,7 @@ const OscillatorControls = ({
             <RadioButtonGroup
               items={WAVEFORMS}
               id={`waveforms${synthNum}`}
-              comparator={synthOptions.type}
+              comparator={type}
               buttonSize="med"
               onValueChange={handleTypeChange}
             />
@@ -65,15 +70,15 @@ const OscillatorControls = ({
               <Knob
                 min={-60}
                 max={0}
-                value={synthOptions.volume}
-                onValueChange={handleVolumechange}
+                value={volume}
+                onValueChange={handleVolumeChange}
                 width={50}
                 height={50}
                 step={1}
               />
               <label className="unselectable title-small">Level</label>
               <span className="tooltip unselectable value">{`${Math.round(
-                synthOptions.volume
+                volume
               )}db`}</span>
             </div>
           </div>
@@ -84,7 +89,7 @@ const OscillatorControls = ({
               <Knob
                 min={-180}
                 max={180}
-                value={synthOptions.phase}
+                value={phase}
                 onValueChange={handlePhaseChange}
                 width={50}
                 height={50}
@@ -92,7 +97,7 @@ const OscillatorControls = ({
               />
               <label className="unselectable title-small">Phase</label>
               <span className="tooltip unselectable value">{`${Math.round(
-                synthOptions.phase
+                phase
               )}°`}</span>
             </div>
           </div>
@@ -103,7 +108,7 @@ const OscillatorControls = ({
               <Knob
                 min={-1200}
                 max={1200}
-                value={synthOptions.detune}
+                value={detune}
                 onValueChange={handleDetuneChange}
                 width={50}
                 height={50}
@@ -111,7 +116,7 @@ const OscillatorControls = ({
               />
               <label className="unselectable title-small">Detune</label>
               <span className="tooltip unselectable value">{`${Math.round(
-                synthOptions.detune
+                detune
               )}cents`}</span>
             </div>
           </div>

--- a/src/components/OscillatorControls.tsx
+++ b/src/components/OscillatorControls.tsx
@@ -52,8 +52,7 @@ const OscillatorControls = ({
               items={WAVEFORMS}
               id={`waveforms${synthNum}`}
               comparator={synthOptions.type}
-              buttonWidth={26}
-              buttonHeight={26}
+              buttonSize="med"
               onValueChange={handleTypeChange}
             />
           </div>

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -23,7 +23,7 @@ const RadioButton = ({
         className="radio-button"
       />
       <label
-        className={`radio-icon ${size}`}
+        className={`radio-icon ${size} unselectable`}
         htmlFor={`${name}${value}`}
         data-testid={value + "label"}
       >

--- a/src/components/RadioButton.tsx
+++ b/src/components/RadioButton.tsx
@@ -1,14 +1,13 @@
 import { Fragment, memo } from "react";
 import { RadioButtonProps } from "../types";
 import * as Icons from "../icons";
-import "../styles/Button.css";
+import "../styles/RadioButton.css";
 
 const RadioButton = ({
   value,
   name,
   selected,
-  height,
-  width,
+  size,
   onValueChange,
 }: RadioButtonProps) => {
   const icon = Icons[value as keyof typeof Icons];
@@ -23,25 +22,13 @@ const RadioButton = ({
         onChange={onValueChange}
         className="radio-button"
       />
-      {icon ? (
-        <label
-          className="radio-icon"
-          htmlFor={`${name}${value}`}
-          style={{ width: width, height: height }}
-          data-testid={value + "label"}
-        >
-          {icon}
-        </label>
-      ) : (
-        <label
-          className="radio-icon unselectable"
-          htmlFor={`${name}${value}`}
-          style={{ width: width, height: height }}
-          data-testid={value + "label"}
-        >
-          {value}
-        </label>
-      )}
+      <label
+        className={`radio-icon ${size}`}
+        htmlFor={`${name}${value}`}
+        data-testid={value + "label"}
+      >
+        {icon ? icon : value}
+      </label>
     </Fragment>
   );
 };

--- a/src/components/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup.tsx
@@ -7,8 +7,7 @@ const RadioButtonGroup = ({
   items,
   id,
   comparator,
-  buttonWidth,
-  buttonHeight,
+  buttonSize,
   onValueChange,
 }: RadioButtonGroupProps) => {
   return (
@@ -20,8 +19,7 @@ const RadioButtonGroup = ({
             name={id}
             value={item}
             selected={comparator === item}
-            width={buttonWidth}
-            height={buttonHeight}
+            size={buttonSize}
             onValueChange={onValueChange}
           />
         );

--- a/src/components/RadioButtonGroup.tsx
+++ b/src/components/RadioButtonGroup.tsx
@@ -12,10 +12,10 @@ const RadioButtonGroup = ({
 }: RadioButtonGroupProps) => {
   return (
     <>
-      {items.map((item, i) => {
+      {items.map((item) => {
         return (
           <RadioButton
-            key={`${id}${i}`}
+            key={`${id}${item}`}
             name={id}
             value={item}
             selected={comparator === item}

--- a/src/components/SynthController.tsx
+++ b/src/components/SynthController.tsx
@@ -12,6 +12,7 @@ import {
   BitCrusher,
   Destination,
   FFT,
+  Synth,
 } from "tone";
 
 import OscillatorControls from "./OscillatorControls";
@@ -48,12 +49,12 @@ class SynthController extends Component<{}, SynthControllerState> {
   constructor(props: any) {
     super(props);
     this.state = {
-      baseOctave: 2,
+      baseOctave: 3,
       notesPlaying: [],
       dragging: false,
     };
-    this.synth1 = new PolySynth();
-    this.synth2 = new PolySynth();
+    this.synth1 = new PolySynth(Synth, defaults.synth1);
+    this.synth2 = new PolySynth(Synth, defaults.synth2);
     this.node1 = new Gain(0.5);
     this.node2 = new Gain(0.5);
     this.filter = new Filter(defaults.filter);
@@ -64,7 +65,6 @@ class SynthController extends Component<{}, SynthControllerState> {
     this.delay = new FeedbackDelay(defaults.delay);
     this.bitCrusher = new BitCrusher(defaults.bitCrusher);
     this.fft = new FFT(512);
-
     this.init();
   }
 
@@ -78,42 +78,19 @@ class SynthController extends Component<{}, SynthControllerState> {
     document.removeEventListener("keyup", this.onKeyUp);
   }
 
-  initSynths = () => {
-    //set default values for synth1
+  initEnvelopes = () => {
+    //set envelopes values for synth1
     this.synth1.set({
-      volume: defaults.synth1.volume,
-      detune: defaults.synth1.detune,
-      oscillator: {
-        type: defaults.synth1.type,
-        phase: defaults.synth1.phase,
-      },
-      envelope: {
-        attack: defaults.envelope.attack,
-        decay: defaults.envelope.decay,
-        sustain: defaults.envelope.sustain,
-        release: defaults.envelope.release,
-      },
+      envelope: defaults.envelope,
     });
-
-    // set default values for synth2
+    // set envelopes values for synth2
     this.synth2.set({
-      volume: defaults.synth2.volume,
-      detune: defaults.synth2.detune,
-      oscillator: {
-        type: defaults.synth2.type,
-        phase: defaults.synth2.phase,
-      },
-      envelope: {
-        attack: defaults.envelope.attack,
-        decay: defaults.envelope.decay,
-        sustain: defaults.envelope.sustain,
-        release: defaults.envelope.release,
-      },
+      envelope: defaults.envelope,
     });
   };
 
   init = () => {
-    this.initSynths();
+    this.initEnvelopes();
 
     //send each synth through a Gain node to prevent clipping
     this.synth1.connect(this.node1);
@@ -123,7 +100,7 @@ class SynthController extends Component<{}, SynthControllerState> {
     this.node1.connect(this.filter);
     this.node2.connect(this.filter);
 
-    //connect the filter -> distortion -> EQ3 -> bitCrusher -> delay -> reverb -> masterVolume -> fft
+    //connect the filter -> EQ3 -> distortion -> bitCrusher -> delay -> reverb -> masterVolume -> fft
     this.filter.chain(
       this.eq3,
       this.distortion,

--- a/src/components/SynthController.tsx
+++ b/src/components/SynthController.tsx
@@ -27,6 +27,8 @@ import { KEY_TO_FULLNOTE, VALID_KEYS } from "../globals/constants";
 
 import { SynthControllerState } from "../types";
 
+import { defaults } from "../presets";
+
 import "../styles/SynthController.css";
 
 class SynthController extends Component<{}, SynthControllerState> {
@@ -48,77 +50,71 @@ class SynthController extends Component<{}, SynthControllerState> {
     this.state = {
       baseOctave: 2,
       notesPlaying: [],
-      masterVolume: -4, // -60 - 0
       dragging: false,
-      synth1Options: {
-        volume: 0, // -60 - 0
-        detune: 0, //-1200 - 1200
-        type: "sine", //sine | square | triangle | saw
-        phase: 0, //-180 - 180
-      },
-      synth2Options: {
-        volume: -10,
-        detune: 0,
-        type: "square",
-        phase: 0,
-      },
-      envelopeOptions: {
-        attack: 0.01, // 0 - 2
-        decay: 1, // 0 - 2
-        sustain: 0.1, // 0 - 1
-        release: 1, // 0 - 5
-      },
-      filterOptions: {
-        Q: 2, // 0 - 20
-        frequency: 400, // 20 - 20k
-        gain: 0, // 0 - 5
-        rolloff: -12, // -12 | -24 | -48 | -96
-        type: "allpass", // lowpass | highpass | lowshelf | highshelf | notch | allpass | bandpass
-      },
-      reverbOptions: {
-        decay: 1, // 1 - 30
-        wet: 0, // 0 - 1
-      },
-      eq3Options: {
-        low: 0,
-        mid: 0,
-        high: 0,
-        lowFrequency: 250,
-        highFrequency: 2500,
-      },
-      distortionOptions: {
-        distortion: 0,
-        wet: 0,
-      },
-      delayOptions: {
-        wet: 0,
-        delayTime: 0,
-        feedback: 0.2,
-      },
-      bitCrusherOptions: {
-        wet: 0,
-        bits: 16,
-      },
     };
     this.synth1 = new PolySynth();
     this.synth2 = new PolySynth();
     this.node1 = new Gain(0.5);
     this.node2 = new Gain(0.5);
-    this.filter = new Filter(this.state.filterOptions);
-    this.masterVolume = new Volume();
-    this.reverb = new Reverb(this.state.reverbOptions);
-    this.eq3 = new EQ3(this.state.eq3Options);
-    this.distortion = new Distortion(this.state.distortionOptions);
-    this.delay = new FeedbackDelay(this.state.delayOptions);
-    this.bitCrusher = new BitCrusher(this.state.bitCrusherOptions);
-    this.fft = new FFT({ size: 512 });
+    this.filter = new Filter(defaults.filter);
+    this.masterVolume = new Volume(defaults.masterVolume);
+    this.reverb = new Reverb(defaults.reverb);
+    this.eq3 = new EQ3(defaults.eq3);
+    this.distortion = new Distortion(defaults.distortion);
+    this.delay = new FeedbackDelay(defaults.delay);
+    this.bitCrusher = new BitCrusher(defaults.bitCrusher);
+    this.fft = new FFT(512);
+
+    this.init();
   }
 
   componentDidMount() {
     document.addEventListener("keydown", this.onKeyDown);
     document.addEventListener("keyup", this.onKeyUp);
+  }
 
+  componentWillUnmount() {
+    document.removeEventListener("keydown", this.onKeyDown);
+    document.removeEventListener("keyup", this.onKeyUp);
+  }
+
+  initSynths = () => {
+    //set default values for synth1
+    this.synth1.set({
+      volume: defaults.synth1.volume,
+      detune: defaults.synth1.detune,
+      oscillator: {
+        type: defaults.synth1.type,
+        phase: defaults.synth1.phase,
+      },
+      envelope: {
+        attack: defaults.envelope.attack,
+        decay: defaults.envelope.decay,
+        sustain: defaults.envelope.sustain,
+        release: defaults.envelope.release,
+      },
+    });
+
+    // set default values for synth2
+    this.synth2.set({
+      volume: defaults.synth2.volume,
+      detune: defaults.synth2.detune,
+      oscillator: {
+        type: defaults.synth2.type,
+        phase: defaults.synth2.phase,
+      },
+      envelope: {
+        attack: defaults.envelope.attack,
+        decay: defaults.envelope.decay,
+        sustain: defaults.envelope.sustain,
+        release: defaults.envelope.release,
+      },
+    });
+  };
+
+  init = () => {
     this.initSynths();
+
     //send each synth through a Gain node to prevent clipping
     this.synth1.connect(this.node1);
     this.synth2.connect(this.node2);
@@ -138,45 +134,6 @@ class SynthController extends Component<{}, SynthControllerState> {
       this.fft,
       Destination
     );
-  }
-
-  componentWillUnmount() {
-    document.removeEventListener("keydown", this.onKeyDown);
-    document.removeEventListener("keyup", this.onKeyUp);
-  }
-
-  initSynths = () => {
-    //set default values for synth1
-    this.synth1.set({
-      volume: this.state.synth1Options.volume,
-      detune: this.state.synth1Options.detune,
-      oscillator: {
-        type: this.state.synth1Options.type,
-        phase: this.state.synth1Options.phase,
-      },
-      envelope: {
-        attack: this.state.envelopeOptions.attack,
-        decay: this.state.envelopeOptions.decay,
-        sustain: this.state.envelopeOptions.sustain,
-        release: this.state.envelopeOptions.release,
-      },
-    });
-
-    // set default values for synth2
-    this.synth2.set({
-      volume: this.state.synth2Options.volume,
-      detune: this.state.synth2Options.detune,
-      oscillator: {
-        type: this.state.synth2Options.type,
-        phase: this.state.synth2Options.phase,
-      },
-      envelope: {
-        attack: this.state.envelopeOptions.attack,
-        decay: this.state.envelopeOptions.decay,
-        sustain: this.state.envelopeOptions.sustain,
-        release: this.state.envelopeOptions.release,
-      },
-    });
   };
 
   onKeyDown = (event: KeyboardEvent) => {

--- a/src/components/SynthController.tsx
+++ b/src/components/SynthController.tsx
@@ -11,7 +11,6 @@ import {
   FeedbackDelay,
   BitCrusher,
   Destination,
-  FilterRollOff,
   FFT,
 } from "tone";
 
@@ -266,22 +265,6 @@ class SynthController extends Component<{}, SynthControllerState> {
     }));
   };
 
-  setFilterOption = (
-    value: number | FilterRollOff | BiquadFilterType,
-    target: "type" | "rolloff" | "Q" | "frequency" | "gain"
-  ) => {
-    this.filter.set({
-      [target]: value,
-    });
-
-    this.setState((prevState) => ({
-      filterOptions: {
-        ...prevState.filterOptions,
-        [target]: value,
-      },
-    }));
-  };
-
   setDelayOption = (
     value: number,
     target: "wet" | "delayTime" | "feedback"
@@ -353,8 +336,7 @@ class SynthController extends Component<{}, SynthControllerState> {
             setEnvelopeOption={this.setEnvelopeOption}
           />
           <FilterControls
-            filterOptions={this.state.filterOptions}
-            setFilterOption={this.setFilterOption}
+            filter={this.filter}
             isPlaying={this.state.notesPlaying.length > 0}
             fft={this.fft}
           />

--- a/src/components/SynthController.tsx
+++ b/src/components/SynthController.tsx
@@ -247,24 +247,6 @@ class SynthController extends Component<{}, SynthControllerState> {
     }
   };
 
-  setEnvelopeOption = (
-    value: number,
-    target: "attack" | "decay" | "sustain" | "release"
-  ) => {
-    this.synth1.set({
-      envelope: { [target]: value },
-    });
-    this.synth2.set({
-      envelope: { [target]: value },
-    });
-    this.setState((prevState) => ({
-      envelopeOptions: {
-        ...prevState.envelopeOptions,
-        [target]: value,
-      },
-    }));
-  };
-
   setDelayOption = (
     value: number,
     target: "wet" | "delayTime" | "feedback"
@@ -331,10 +313,7 @@ class SynthController extends Component<{}, SynthControllerState> {
         <div className="top-container">
           <OscillatorControls synthNum={1} synth={this.synth1} />
           <OscillatorControls synthNum={2} synth={this.synth2} />
-          <EnvelopeControls
-            envelopeOptions={this.state.envelopeOptions}
-            setEnvelopeOption={this.setEnvelopeOption}
-          />
+          <EnvelopeControls synth1={this.synth1} synth2={this.synth2} />
           <FilterControls
             filter={this.filter}
             isPlaying={this.state.notesPlaying.length > 0}

--- a/src/components/SynthController.tsx
+++ b/src/components/SynthController.tsx
@@ -247,55 +247,6 @@ class SynthController extends Component<{}, SynthControllerState> {
     }
   };
 
-  setDelayOption = (
-    value: number,
-    target: "wet" | "delayTime" | "feedback"
-  ) => {
-    this.delay.set({ [target]: value });
-    this.setState((prevState) => ({
-      delayOptions: {
-        ...prevState.delayOptions,
-        [target]: value,
-      },
-    }));
-  };
-
-  setBitCrusherOption = (value: number, target: "wet" | "bits") => {
-    this.bitCrusher.set({ [target]: value });
-    this.setState((prevState) => ({
-      bitCrusherOptions: {
-        ...prevState.bitCrusherOptions,
-        [target]: value,
-      },
-    }));
-  };
-
-  setDistortionOption = (value: number, target: "wet" | "distortion") => {
-    this.distortion.set({
-      [target]: value,
-    });
-
-    this.setState((prevState) => ({
-      distortionOptions: {
-        ...prevState.distortionOptions,
-        [target]: value,
-      },
-    }));
-  };
-
-  setReverbOption = (value: number, target: "wet" | "decay") => {
-    this.reverb.set({
-      [target]: value,
-    });
-
-    this.setState((prevState) => ({
-      reverbOptions: {
-        ...prevState.reverbOptions,
-        [target]: value,
-      },
-    }));
-  };
-
   setBaseOctave = (value: number) => {
     this.setState({ baseOctave: value });
     //stop all notes in notesPlaying
@@ -321,14 +272,10 @@ class SynthController extends Component<{}, SynthControllerState> {
           />
           <EQ3Controls eq3={this.eq3} />
           <EffectsControls
-            reverbOptions={this.state.reverbOptions}
-            setReverbOption={this.setReverbOption}
-            distortionOptions={this.state.distortionOptions}
-            setDistortionOption={this.setDistortionOption}
-            delayOptions={this.state.delayOptions}
-            setDelayOption={this.setDelayOption}
-            bitCrusherOptions={this.state.bitCrusherOptions}
-            setBitCrusherOption={this.setBitCrusherOption}
+            reverb={this.reverb}
+            distortion={this.distortion}
+            delay={this.delay}
+            bitCrusher={this.bitCrusher}
           />
         </div>
         <div className="bottom-container">

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,0 +1,56 @@
+import { preset } from "../types";
+
+const defaults: preset = {
+  synth1: {
+    volume: 0, // -60 - 0
+    detune: 0, //-1200 - 1200
+    type: "sine", //sine | square | triangle | saw
+    phase: 0, //-180 - 180
+  },
+  synth2: {
+    volume: -10,
+    detune: 0,
+    type: "square",
+    phase: 0,
+  },
+  envelope: {
+    attack: 0.01, // 0 - 2
+    decay: 1, // 0 - 2
+    sustain: 0.1, // 0 - 1
+    release: 1, // 0 - 5
+  },
+  filter: {
+    Q: 2, // 0 - 20
+    frequency: 400, // 20 - 20k
+    gain: 0, // 0 - 5
+    rolloff: -12, // -12 | -24 | -48 | -96
+    type: "allpass", // lowpass | highpass | lowshelf | highshelf | notch | allpass | bandpass
+  },
+  reverb: {
+    decay: 1, // 1 - 30
+    wet: 0, // 0 - 1
+  },
+  eq3: {
+    low: 0,
+    mid: 0,
+    high: 0,
+    lowFrequency: 250,
+    highFrequency: 2500,
+  },
+  distortion: {
+    distortion: 0,
+    wet: 0,
+  },
+  delay: {
+    wet: 0,
+    delayTime: 0,
+    feedback: 0.2,
+  },
+  bitCrusher: {
+    wet: 0,
+    bits: 16,
+  },
+  masterVolume: -2, // -60 - 0
+};
+
+export { defaults };

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -4,20 +4,24 @@ const defaults: preset = {
   synth1: {
     volume: 0, // -60 - 0
     detune: 0, //-1200 - 1200
-    type: "sine", //sine | square | triangle | saw
-    phase: 0, //-180 - 180
+    oscillator: {
+      type: "sine", //sine | square | triangle | sawtooth
+      phase: 0, //-180 - 180
+    },
   },
   synth2: {
     volume: -10,
     detune: 0,
-    type: "square",
-    phase: 0,
+    oscillator: {
+      type: "square",
+      phase: 0,
+    },
   },
   envelope: {
     attack: 0.01, // 0 - 2
-    decay: 1, // 0 - 2
-    sustain: 0.1, // 0 - 1
-    release: 1, // 0 - 5
+    decay: 0, // 0 - 2
+    sustain: 1, // 0 - 1
+    release: 0.01, // 0 - 5
   },
   filter: {
     Q: 2, // 0 - 20

--- a/src/styles/FilterControls.css
+++ b/src/styles/FilterControls.css
@@ -1,0 +1,9 @@
+.type-buttons {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.rolloff-buttons {
+  display: grid;
+  grid-template-columns: 36px 36px;
+}

--- a/src/styles/FilterDisplay.css
+++ b/src/styles/FilterDisplay.css
@@ -10,11 +10,6 @@ canvas {
   -webkit-font-smoothing: none;
 }
 
-.filter-type-buttons {
-  margin-top: 10px;
-  margin-bottom: 10px;
-}
-
 .holder {
   width: 256px;
   height: 156px;

--- a/src/styles/RadioButton.css
+++ b/src/styles/RadioButton.css
@@ -28,3 +28,18 @@ input:checked + label {
 input:not(:checked) + .radio-icon:hover {
   background-color: white;
 }
+
+.radio-icon.large {
+  width: 28px;
+  height: 28px;
+}
+
+.radio-icon.med {
+  width: 26px;
+  height: 26px;
+}
+
+.radio-icon.small {
+  width: 26px;
+  height: 12px;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,16 @@
 import { ChangeEvent } from "react";
-import { FFT, FilterRollOff, Volume, EQ3, PolySynth, Filter } from "tone";
+import {
+  FFT,
+  FilterRollOff,
+  Volume,
+  EQ3,
+  PolySynth,
+  Filter,
+  FeedbackDelay,
+  Reverb,
+  Distortion,
+  BitCrusher,
+} from "tone";
 
 export type synthOptions = {
   volume: number;
@@ -102,17 +113,10 @@ export type FilterDisplayProps = {
 };
 
 export type EffectsControlsProps = {
-  reverbOptions: reverbOptions;
-  distortionOptions: distortionOptions;
-  delayOptions: delayOptions;
-  bitCrusherOptions: bitCrusherOptions;
-  setReverbOption: (value: number, target: "wet" | "decay") => void;
-  setDistortionOption: (value: number, target: "wet" | "distortion") => void;
-  setDelayOption: (
-    value: number,
-    target: "wet" | "delayTime" | "feedback"
-  ) => void;
-  setBitCrusherOption: (value: number, target: "wet" | "bits") => void;
+  reverb: Reverb;
+  distortion: Distortion;
+  delay: FeedbackDelay;
+  bitCrusher: BitCrusher;
 };
 
 export type EQ3ControlsProps = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -81,11 +81,8 @@ export type OscillatorControlsProps = {
 };
 
 export type EnvelopeControlsProps = {
-  envelopeOptions: envelopeOptions;
-  setEnvelopeOption: (
-    value: number,
-    target: "attack" | "decay" | "sustain" | "release"
-  ) => void;
+  synth1: PolySynth;
+  synth2: PolySynth;
 };
 
 export type FilterControlsProps = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,8 +157,7 @@ export type RadioButtonProps = {
   value: string;
   name: string;
   selected: boolean;
-  height: number;
-  width: number;
+  size: string;
   onValueChange: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 
@@ -166,8 +165,7 @@ export type RadioButtonGroupProps = {
   items: string[];
   id: string;
   comparator: string;
-  buttonWidth: number;
-  buttonHeight: number;
+  buttonSize: string;
   onValueChange: (e: ChangeEvent<HTMLInputElement>) => void;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,13 +11,13 @@ import {
   BitCrusher,
   EnvelopeOptions,
   FilterOptions,
+  OmniOscillatorOptions,
 } from "tone";
 
 type synthOptions = {
   volume: number;
   detune: number;
-  type: OscillatorType;
-  phase: number;
+  oscillator: Partial<OmniOscillatorOptions>;
 };
 
 type reverbOptions = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,6 @@
 import { ChangeEvent } from "react";
 import {
   FFT,
-  FilterRollOff,
   Volume,
   EQ3,
   PolySynth,
@@ -10,36 +9,23 @@ import {
   Reverb,
   Distortion,
   BitCrusher,
+  EnvelopeOptions,
+  FilterOptions,
 } from "tone";
 
-export type synthOptions = {
+type synthOptions = {
   volume: number;
   detune: number;
   type: OscillatorType;
   phase: number;
 };
 
-export type envelopeOptions = {
-  attack: number;
-  decay: number;
-  sustain: number;
-  release: number;
-};
-
-export type filterOptions = {
-  Q: number;
-  frequency: number;
-  gain: number;
-  rolloff: FilterRollOff;
-  type: BiquadFilterType;
-};
-
-export type reverbOptions = {
+type reverbOptions = {
   wet: number;
   decay: number;
 };
 
-export type eq3Options = {
+type eq3Options = {
   low: number;
   mid: number;
   high: number;
@@ -47,33 +33,36 @@ export type eq3Options = {
   highFrequency: number;
 };
 
-export type distortionOptions = { distortion: number; wet: number };
+type distortionOptions = { distortion: number; wet: number };
 
-export type delayOptions = {
+type delayOptions = {
   wet: number;
   delayTime: number;
   feedback: number;
 };
 
-export type bitCrusherOptions = {
+type bitCrusherOptions = {
   wet: number;
   bits: number;
+};
+
+export type preset = {
+  synth1: synthOptions;
+  synth2: synthOptions;
+  envelope: Partial<EnvelopeOptions>;
+  filter: Partial<FilterOptions>;
+  reverb: reverbOptions;
+  eq3: eq3Options;
+  distortion: distortionOptions;
+  delay: delayOptions;
+  bitCrusher: bitCrusherOptions;
+  masterVolume: number;
 };
 
 export type SynthControllerState = {
   baseOctave: number;
   notesPlaying: string[];
-  masterVolume: number;
   dragging: boolean;
-  synth1Options: synthOptions;
-  synth2Options: synthOptions;
-  envelopeOptions: envelopeOptions;
-  filterOptions: filterOptions;
-  reverbOptions: reverbOptions;
-  eq3Options: eq3Options;
-  distortionOptions: distortionOptions;
-  delayOptions: delayOptions;
-  bitCrusherOptions: bitCrusherOptions;
 };
 
 export type ControlProps = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent } from "react";
-import { FFT, FilterRollOff } from "tone";
+import { FFT, FilterRollOff, Volume, EQ3, PolySynth } from "tone";
 
 export type synthOptions = {
   volume: number;
@@ -77,12 +77,7 @@ export type ControlProps = {
 
 export type OscillatorControlsProps = {
   synthNum: 1 | 2;
-  synthOptions: synthOptions;
-  setSynthOption: (
-    value: OscillatorType | number,
-    target: "type" | "phase" | "volume" | "detune",
-    synthNum: 1 | 2
-  ) => void;
+  synth: PolySynth;
 };
 
 export type EnvelopeControlsProps = {
@@ -124,18 +119,13 @@ export type EffectsControlsProps = {
 };
 
 export type EQ3ControlsProps = {
-  eq3Options: eq3Options;
-  setEQ3Option: (
-    value: number,
-    target: "low" | "mid" | "high" | "lowFrequency" | "highFrequency"
-  ) => void;
+  eq3: EQ3;
 };
 
 export type MasterControlsProps = {
-  volume: number;
+  masterVolume: Volume;
   octave: number;
   setOctave: (octave: number) => void;
-  setVolume: (value: number) => void;
 };
 
 export type KeyProps = {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import { ChangeEvent } from "react";
-import { FFT, FilterRollOff, Volume, EQ3, PolySynth } from "tone";
+import { FFT, FilterRollOff, Volume, EQ3, PolySynth, Filter } from "tone";
 
 export type synthOptions = {
   volume: number;
@@ -89,17 +89,17 @@ export type EnvelopeControlsProps = {
 };
 
 export type FilterControlsProps = {
-  filterOptions: filterOptions;
-  setFilterOption: (
-    value: number | FilterRollOff | BiquadFilterType,
-    target: "type" | "rolloff" | "Q" | "frequency" | "gain"
-  ) => void;
+  filter: Filter;
   isPlaying: boolean;
   fft: FFT;
 };
 
 export type FilterDisplayProps = {
-  filterOptions: filterOptions;
+  type: string;
+  rolloff: number;
+  q: number;
+  freq: number;
+  gain: number;
   isPlaying: boolean;
   fft: FFT;
 };


### PR DESCRIPTION
Refactor of code to remove React anti-patterns and organize/cleanup.

- Remove the few inline styles
- Create unique keys for uses of .map() (no longer index)
- Use React event handlers when possible
- Break-up giant state object from SynthController and move parts to each specific individual component
- Create default preset for future use in savable settings
- A few name changes and organization for consistency
- Lots of cleaning