### PR TITLE
Feature/save settings

### DIFF
--- a/src/components/EQ3Controls.tsx
+++ b/src/components/EQ3Controls.tsx
@@ -1,14 +1,22 @@
-import { useState, useCallback, memo } from "react";
+import { useState, useCallback, memo, useEffect } from "react";
 import Knob from "./Knob";
 import { EQ3ControlsProps } from "../types";
 import "../styles/EQ3Controls.css";
 
-const EQ3Controls = ({ eq3 }: EQ3ControlsProps) => {
+const EQ3Controls = ({ eq3, update }: EQ3ControlsProps) => {
   const [low, setLow] = useState(eq3.low.value);
   const [mid, setMid] = useState(eq3.mid.value);
   const [high, setHigh] = useState(eq3.high.value);
   const [lowFreq, setLowFreq] = useState(eq3.lowFrequency.value as number);
   const [highFreq, setHighFreq] = useState(eq3.highFrequency.value as number);
+
+  useEffect(() => {
+    setLow(eq3.low.value);
+    setMid(eq3.mid.value);
+    setLow(eq3.high.value);
+    setLowFreq(eq3.lowFrequency.value as number);
+    setHighFreq(eq3.highFrequency.value as number);
+  }, [update, eq3]);
 
   const handleLowChange = useCallback(
     (value: number) => {

--- a/src/components/EQ3Controls.tsx
+++ b/src/components/EQ3Controls.tsx
@@ -1,61 +1,71 @@
-import { useState, useCallback, memo, useEffect } from "react";
+import { useCallback, memo, useContext } from "react";
 import Knob from "./Knob";
 import { EQ3ControlsProps } from "../types";
 import "../styles/EQ3Controls.css";
+import { OptionsContext } from "../contexts/OptionsContext";
 
-const EQ3Controls = ({ eq3, update }: EQ3ControlsProps) => {
-  const [low, setLow] = useState(eq3.low.value);
-  const [mid, setMid] = useState(eq3.mid.value);
-  const [high, setHigh] = useState(eq3.high.value);
-  const [lowFreq, setLowFreq] = useState(eq3.lowFrequency.value as number);
-  const [highFreq, setHighFreq] = useState(eq3.highFrequency.value as number);
+const EQ3Controls = ({ eq3 }: EQ3ControlsProps) => {
+  const low = eq3.low.value;
+  const mid = eq3.mid.value;
+  const high = eq3.high.value;
+  const lowFreq = eq3.lowFrequency.value as number;
+  const highFreq = eq3.highFrequency.value as number;
 
-  useEffect(() => {
-    setLow(eq3.low.value);
-    setMid(eq3.mid.value);
-    setHigh(eq3.high.value);
-    setLowFreq(eq3.lowFrequency.value as number);
-    setHighFreq(eq3.highFrequency.value as number);
-  }, [update, eq3]);
+  const optionsContext = useContext(OptionsContext);
 
   const handleLowChange = useCallback(
     (value: number) => {
       eq3.set({ low: value });
-      setLow(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.eq3.low = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [eq3]
+    [eq3, optionsContext]
   );
 
   const handleMidChange = useCallback(
     (value: number) => {
       eq3.set({ mid: value });
-      setMid(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.eq3.mid = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [eq3]
+    [eq3, optionsContext]
   );
 
   const handleHighChange = useCallback(
     (value: number) => {
       eq3.set({ high: value });
-      setHigh(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.eq3.high = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [eq3]
+    [eq3, optionsContext]
   );
 
   const handleLowFreqChange = useCallback(
     (value: number) => {
       eq3.set({ lowFrequency: value });
-      setLowFreq(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.eq3.lowFrequency = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [eq3]
+    [eq3, optionsContext]
   );
 
   const handleHighFreqChange = useCallback(
     (value: number) => {
       eq3.set({ highFrequency: value });
-      setHighFreq(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.eq3.highFrequency = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [eq3]
+    [eq3, optionsContext]
   );
 
   return (

--- a/src/components/EQ3Controls.tsx
+++ b/src/components/EQ3Controls.tsx
@@ -13,7 +13,7 @@ const EQ3Controls = ({ eq3, update }: EQ3ControlsProps) => {
   useEffect(() => {
     setLow(eq3.low.value);
     setMid(eq3.mid.value);
-    setLow(eq3.high.value);
+    setHigh(eq3.high.value);
     setLowFreq(eq3.lowFrequency.value as number);
     setHighFreq(eq3.highFrequency.value as number);
   }, [update, eq3]);

--- a/src/components/EffectsControls.tsx
+++ b/src/components/EffectsControls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, memo } from "react";
+import { useCallback, useState, memo, useEffect } from "react";
 import Knob from "./Knob";
 import { EffectsControlsProps } from "../types";
 import "../styles/EffectsControls.css";
@@ -8,6 +8,7 @@ const EffectsControls = ({
   distortion,
   delay,
   bitCrusher,
+  update,
 }: EffectsControlsProps) => {
   const [delayWet, setDelayWet] = useState(delay.get().wet);
   const [delayTime, setDelayTime] = useState(Number(delay.get().delayTime));
@@ -20,6 +21,16 @@ const EffectsControls = ({
   );
   const [bitCrusherWet, setBitCrusherWet] = useState(bitCrusher.get().wet);
   const [bitCrusherBits, setBitCrusherBits] = useState(bitCrusher.get().bits);
+
+  useEffect(() => {
+    setDelayWet(delay.get().wet);
+    setDelayTime(Number(delay.get().delayTime));
+    setDelayFeedback(delay.get().feedback);
+    setReverbWet(reverb.get().wet);
+    setReverbDecay(reverb.get().decay);
+    setDistortionWet(distortion.get().wet);
+    setDistortionAmount(distortion.get().distortion);
+  }, [update, reverb, distortion, delay, bitCrusher]);
 
   const handleDelayWetChange = useCallback(
     (value: number) => {

--- a/src/components/EffectsControls.tsx
+++ b/src/components/EffectsControls.tsx
@@ -1,109 +1,124 @@
-import { useCallback, useState, memo, useEffect } from "react";
+import { useCallback, memo, useContext } from "react";
 import Knob from "./Knob";
 import { EffectsControlsProps } from "../types";
 import "../styles/EffectsControls.css";
+import { OptionsContext } from "../contexts/OptionsContext";
 
 const EffectsControls = ({
   reverb,
   distortion,
   delay,
   bitCrusher,
-  update,
 }: EffectsControlsProps) => {
-  const [delayWet, setDelayWet] = useState(delay.get().wet);
-  const [delayTime, setDelayTime] = useState(Number(delay.get().delayTime));
-  const [delayFeedback, setDelayFeedback] = useState(delay.get().feedback);
-  const [reverbWet, setReverbWet] = useState(reverb.get().wet);
-  const [reverbDecay, setReverbDecay] = useState(reverb.get().decay);
-  const [distortionWet, setDistortionWet] = useState(distortion.get().wet);
-  const [distortionAmount, setDistortionAmount] = useState(
-    distortion.get().distortion
-  );
-  const [bitCrusherWet, setBitCrusherWet] = useState(bitCrusher.get().wet);
-  const [bitCrusherBits, setBitCrusherBits] = useState(bitCrusher.get().bits);
+  const delayWet = delay.get().wet;
+  const delayTime = Number(delay.get().delayTime);
+  const delayFeedback = delay.get().feedback;
+  const reverbWet = reverb.get().wet;
+  const reverbDecay = reverb.get().decay;
+  const distortionWet = distortion.get().wet;
+  const distortionAmount = distortion.get().distortion;
+  const bitCrusherWet = bitCrusher.get().wet;
+  const bitCrusherBits = bitCrusher.get().bits;
 
-  useEffect(() => {
-    setDelayWet(delay.get().wet);
-    setDelayTime(Number(delay.get().delayTime));
-    setDelayFeedback(delay.get().feedback);
-    setReverbWet(reverb.get().wet);
-    setReverbDecay(reverb.get().decay);
-    setDistortionWet(distortion.get().wet);
-    setDistortionAmount(distortion.get().distortion);
-    setBitCrusherWet(bitCrusher.get().wet);
-    setBitCrusherBits(bitCrusher.get().bits);
-  }, [update, reverb, distortion, delay, bitCrusher]);
+  const optionsContext = useContext(OptionsContext);
 
   const handleDelayWetChange = useCallback(
     (value: number) => {
       delay.set({ wet: value });
-      setDelayWet(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.delay.wet = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [delay]
+    [delay, optionsContext]
   );
 
   const handleDelayTimeChange = useCallback(
     (value: number) => {
       delay.set({ delayTime: value });
-      setDelayTime(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.delay.delayTime = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [delay]
+    [delay, optionsContext]
   );
 
   const handleDelayFeedbackChange = useCallback(
     (value: number) => {
       delay.set({ feedback: value });
-      setDelayFeedback(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.delay.feedback = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [delay]
+    [delay, optionsContext]
   );
 
   const handleReverbWetChange = useCallback(
     (value: number) => {
       reverb.set({ wet: value });
-      setReverbWet(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.reverb.wet = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [reverb]
+    [reverb, optionsContext]
   );
 
   const handleReverbDecayChange = useCallback(
     (value: number) => {
       reverb.set({ decay: value });
-      setReverbDecay(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.reverb.decay = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [reverb]
+    [reverb, optionsContext]
   );
 
   const handleDistortionWetChange = useCallback(
     (value: number) => {
       distortion.set({ wet: value });
-      setDistortionWet(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.distortion.wet = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [distortion]
+    [distortion, optionsContext]
   );
 
   const handleDistortionChange = useCallback(
     (value: number) => {
       distortion.set({ distortion: value });
-      setDistortionAmount(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.distortion.distortion = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [distortion]
+    [distortion, optionsContext]
   );
 
   const handleBitCrusherWetChange = useCallback(
     (value: number) => {
       bitCrusher.set({ wet: value });
-      setBitCrusherWet(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.bitCrusher.wet = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [bitCrusher]
+    [bitCrusher, optionsContext]
   );
 
   const handleBitCrusherBitsChange = useCallback(
     (value: number) => {
       bitCrusher.set({ bits: value });
-      setBitCrusherBits(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.bitCrusher.bits = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [bitCrusher]
+    [bitCrusher, optionsContext]
   );
 
   return (

--- a/src/components/EffectsControls.tsx
+++ b/src/components/EffectsControls.tsx
@@ -30,6 +30,8 @@ const EffectsControls = ({
     setReverbDecay(reverb.get().decay);
     setDistortionWet(distortion.get().wet);
     setDistortionAmount(distortion.get().distortion);
+    setBitCrusherWet(bitCrusher.get().wet);
+    setBitCrusherBits(bitCrusher.get().bits);
   }, [update, reverb, distortion, delay, bitCrusher]);
 
   const handleDelayWetChange = useCallback(

--- a/src/components/EnvelopeControls.tsx
+++ b/src/components/EnvelopeControls.tsx
@@ -1,12 +1,23 @@
-import { useCallback, useState, memo } from "react";
+import { useCallback, useState, memo, useEffect } from "react";
 import Slider from "./Slider";
 import { EnvelopeControlsProps } from "../types";
 
-const EnvelopeControls = ({ synth1, synth2 }: EnvelopeControlsProps) => {
+const EnvelopeControls = ({
+  synth1,
+  synth2,
+  update,
+}: EnvelopeControlsProps) => {
   const [attack, setAttack] = useState(Number(synth1.get().envelope.attack));
   const [decay, setDecay] = useState(Number(synth1.get().envelope.decay));
   const [sustain, setSustain] = useState(synth1.get().envelope.sustain);
   const [release, setRelease] = useState(Number(synth1.get().envelope.release));
+
+  useEffect(() => {
+    setAttack(Number(synth1.get().envelope.attack));
+    setDecay(Number(synth1.get().envelope.decay));
+    setSustain(Number(synth1.get().envelope.sustain));
+    setRelease(Number(synth1.get().envelope.release));
+  }, [update, synth1]);
 
   const handleAttackChange = useCallback(
     (value) => {

--- a/src/components/EnvelopeControls.tsx
+++ b/src/components/EnvelopeControls.tsx
@@ -1,58 +1,62 @@
-import { useCallback, useState, memo, useEffect } from "react";
+import { useCallback, memo, useContext } from "react";
 import Slider from "./Slider";
 import { EnvelopeControlsProps } from "../types";
+import { OptionsContext } from "../contexts/OptionsContext";
 
-const EnvelopeControls = ({
-  synth1,
-  synth2,
-  update,
-}: EnvelopeControlsProps) => {
-  const [attack, setAttack] = useState(Number(synth1.get().envelope.attack));
-  const [decay, setDecay] = useState(Number(synth1.get().envelope.decay));
-  const [sustain, setSustain] = useState(synth1.get().envelope.sustain);
-  const [release, setRelease] = useState(Number(synth1.get().envelope.release));
+const EnvelopeControls = ({ synth1, synth2 }: EnvelopeControlsProps) => {
+  const attack = Number(synth1.get().envelope.attack);
+  const decay = Number(synth1.get().envelope.decay);
+  const sustain = synth1.get().envelope.sustain;
+  const release = Number(synth1.get().envelope.release);
 
-  useEffect(() => {
-    setAttack(Number(synth1.get().envelope.attack));
-    setDecay(Number(synth1.get().envelope.decay));
-    setSustain(Number(synth1.get().envelope.sustain));
-    setRelease(Number(synth1.get().envelope.release));
-  }, [update, synth1]);
+  const optionsContext = useContext(OptionsContext);
 
   const handleAttackChange = useCallback(
     (value) => {
       synth1.set({ envelope: { attack: value } });
       synth2.set({ envelope: { attack: value } });
-      setAttack(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.envelope.attack = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth1, synth2]
+    [synth1, synth2, optionsContext]
   );
 
   const handleDecayChange = useCallback(
     (value) => {
       synth1.set({ envelope: { decay: value } });
       synth2.set({ envelope: { decay: value } });
-      setDecay(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.envelope.decay = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth1, synth2]
+    [synth1, synth2, optionsContext]
   );
 
   const handleSustainChange = useCallback(
     (value) => {
       synth1.set({ envelope: { sustain: value } });
       synth2.set({ envelope: { sustain: value } });
-      setSustain(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.envelope.sustain = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth1, synth2]
+    [synth1, synth2, optionsContext]
   );
 
   const handleReleaseChange = useCallback(
     (value) => {
       synth1.set({ envelope: { release: value } });
       synth2.set({ envelope: { release: value } });
-      setRelease(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.envelope.release = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth1, synth2]
+    [synth1, synth2, optionsContext]
   );
 
   return (

--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, memo, ChangeEvent, useEffect } from "react";
+import { useCallback, memo, ChangeEvent, useContext } from "react";
 import FilterDisplay from "./FilterDisplay";
 import Knob from "./Knob";
 import RadioButtonGroup from "./RadioButtonGroup";
@@ -6,68 +6,72 @@ import { FILTER_TYPES, ROLLOFFS } from "../globals/constants";
 import { FilterControlsProps } from "../types";
 import "../styles/FilterControls.css";
 import { FilterRollOff } from "tone";
+import { OptionsContext } from "../contexts/OptionsContext";
 
-const FilterControls = ({
-  filter,
-  isPlaying,
-  fft,
-  update,
-}: FilterControlsProps) => {
-  const [type, setType] = useState(filter.type);
-  const [rolloff, setRolloff] = useState(filter.rolloff);
-  const [q, setQ] = useState(filter.get().Q);
-  const [freq, setFreq] = useState(
-    filter.frequency.toFrequency(filter.frequency.value)
-  );
-  const [gain, setGain] = useState(filter.get().gain);
+const FilterControls = ({ filter, isPlaying, fft }: FilterControlsProps) => {
+  const type = filter.type;
+  const rolloff = filter.rolloff;
+  const q = filter.get().Q;
+  const freq = filter.frequency.toFrequency(filter.frequency.value);
+  const gain = filter.get().gain;
 
-  useEffect(() => {
-    setType(filter.type);
-    setRolloff(filter.rolloff);
-    setQ(filter.get().Q);
-    setFreq(filter.frequency.toFrequency(filter.frequency.value));
-  }, [update, filter]);
+  const optionsContext = useContext(OptionsContext);
 
   const handleFilterTypeChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value as BiquadFilterType;
       filter.set({ type: value });
-      setType(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.filter.type = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [filter]
+    [filter, optionsContext]
   );
 
   const handleFilterRolloffChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const value = Number(e.target.value) as FilterRollOff;
       filter.set({ rolloff: value });
-      setRolloff(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.filter.rolloff = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [filter]
+    [filter, optionsContext]
   );
 
   const handleFilterQChange = useCallback(
     (value: number) => {
       filter.set({ Q: value });
-      setQ(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.filter.Q = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [filter]
+    [filter, optionsContext]
   );
 
   const handleFilterFrequencyChange = useCallback(
     (value: number) => {
       filter.set({ frequency: value });
-      setFreq(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.filter.frequency = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [filter]
+    [filter, optionsContext]
   );
 
   const handleFilterGainChange = useCallback(
     (value: number) => {
       filter.set({ gain: value });
-      setGain(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.filter.gain = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [filter]
+    [filter, optionsContext]
   );
 
   return (
@@ -87,7 +91,6 @@ const FilterControls = ({
             gain={gain}
             isPlaying={isPlaying}
             fft={fft}
-            update={update}
           />
         </div>
       </div>

--- a/src/components/FilterControls.tsx
+++ b/src/components/FilterControls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState, memo, ChangeEvent } from "react";
+import { useCallback, useState, memo, ChangeEvent, useEffect } from "react";
 import FilterDisplay from "./FilterDisplay";
 import Knob from "./Knob";
 import RadioButtonGroup from "./RadioButtonGroup";
@@ -7,7 +7,12 @@ import { FilterControlsProps } from "../types";
 import "../styles/FilterControls.css";
 import { FilterRollOff } from "tone";
 
-const FilterControls = ({ filter, isPlaying, fft }: FilterControlsProps) => {
+const FilterControls = ({
+  filter,
+  isPlaying,
+  fft,
+  update,
+}: FilterControlsProps) => {
   const [type, setType] = useState(filter.type);
   const [rolloff, setRolloff] = useState(filter.rolloff);
   const [q, setQ] = useState(filter.get().Q);
@@ -15,6 +20,13 @@ const FilterControls = ({ filter, isPlaying, fft }: FilterControlsProps) => {
     filter.frequency.toFrequency(filter.frequency.value)
   );
   const [gain, setGain] = useState(filter.get().gain);
+
+  useEffect(() => {
+    setType(filter.type);
+    setRolloff(filter.rolloff);
+    setQ(filter.get().Q);
+    setFreq(filter.frequency.toFrequency(filter.frequency.value));
+  }, [update, filter]);
 
   const handleFilterTypeChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
@@ -75,6 +87,7 @@ const FilterControls = ({ filter, isPlaying, fft }: FilterControlsProps) => {
             gain={gain}
             isPlaying={isPlaying}
             fft={fft}
+            update={update}
           />
         </div>
       </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { github } from "../icons";
 import "../styles/Footer.css";
 

--- a/src/components/MasterControls.tsx
+++ b/src/components/MasterControls.tsx
@@ -1,4 +1,4 @@
-import { useCallback, memo, useState } from "react";
+import { useCallback, memo, useState, useEffect } from "react";
 import Knob from "./Knob";
 import { MasterControlsProps } from "../types";
 import { left, right } from "../icons";
@@ -8,8 +8,13 @@ const MasterControls = ({
   masterVolume,
   octave,
   setOctave,
+  update,
 }: MasterControlsProps) => {
   const [volume, setVolume] = useState(masterVolume.volume.value);
+
+  useEffect(() => {
+    setVolume(masterVolume.volume.value);
+  }, [update, masterVolume]);
 
   const handleVolumeChange = useCallback(
     (value: number) => {

--- a/src/components/MasterControls.tsx
+++ b/src/components/MasterControls.tsx
@@ -1,27 +1,29 @@
-import { useCallback, memo, useState, useEffect } from "react";
+import { useCallback, memo, useContext } from "react";
 import Knob from "./Knob";
 import { MasterControlsProps } from "../types";
 import { left, right } from "../icons";
 import "../styles/MasterControls.css";
 
+import { OptionsContext } from "../contexts/OptionsContext";
+
 const MasterControls = ({
   masterVolume,
   octave,
   setOctave,
-  update,
 }: MasterControlsProps) => {
-  const [volume, setVolume] = useState(masterVolume.volume.value);
+  const volume = masterVolume.volume.value;
 
-  useEffect(() => {
-    setVolume(masterVolume.volume.value);
-  }, [update, masterVolume]);
+  const optionsContext = useContext(OptionsContext);
 
   const handleVolumeChange = useCallback(
     (value: number) => {
       masterVolume.set({ volume: value });
-      setVolume(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      optionsCopy.masterVolume = value;
+      optionsContext.setOptions(optionsCopy);
     },
-    [masterVolume]
+    [masterVolume, optionsContext]
   );
 
   return (

--- a/src/components/OscillatorControls.tsx
+++ b/src/components/OscillatorControls.tsx
@@ -1,57 +1,73 @@
-import { useCallback, useState, memo, ChangeEvent, useEffect } from "react";
+import { useCallback, memo, ChangeEvent, useContext } from "react";
 import Knob from "./Knob";
 import RadioButtonGroup from "./RadioButtonGroup";
 import { WAVEFORMS } from "../globals/constants";
 import { OscillatorControlsProps } from "../types";
+import { OptionsContext } from "../contexts/OptionsContext";
 
-const OscillatorControls = ({
-  synthNum,
-  synth,
-  update,
-}: OscillatorControlsProps) => {
-  const [type, setType] = useState(synth.get().oscillator.type);
-  const [volume, setVolume] = useState(synth.get().volume);
-  const [phase, setPhase] = useState(synth.get().oscillator.phase);
-  const [detune, setDetune] = useState(synth.get().detune);
+const OscillatorControls = ({ synthNum, synth }: OscillatorControlsProps) => {
+  const type = synth.get().oscillator.type;
+  const volume = synth.get().volume;
+  const phase = synth.get().oscillator.phase;
+  const detune = synth.get().detune;
 
-  useEffect(() => {
-    setType(synth.get().oscillator.type);
-    setVolume(synth.get().volume);
-    setPhase(synth.get().oscillator.phase);
-    setDetune(synth.get().detune);
-  }, [update, synth]);
+  const optionsContext = useContext(OptionsContext);
 
   const handleTypeChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value as OscillatorType;
       synth.set({ oscillator: { type: value } });
-      setType(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      synthNum === 1
+        ? (optionsCopy.synth1.oscillator.type = value)
+        : (optionsCopy.synth2.oscillator.type = value);
+
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth]
+    [synth, optionsContext, synthNum]
   );
 
   const handleVolumeChange = useCallback(
     (value: number) => {
       synth.set({ volume: value });
-      setVolume(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      synthNum === 1
+        ? (optionsCopy.synth1.volume = value)
+        : (optionsCopy.synth2.volume = value);
+
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth]
+    [synth, optionsContext, synthNum]
   );
 
   const handlePhaseChange = useCallback(
     (value: number) => {
       synth.set({ oscillator: { phase: value } });
-      setPhase(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      synthNum === 1
+        ? (optionsCopy.synth1.oscillator.phase = value)
+        : (optionsCopy.synth2.oscillator.phase = value);
+
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth]
+    [synth, optionsContext, synthNum]
   );
 
   const handleDetuneChange = useCallback(
     (value: number) => {
       synth.set({ detune: value });
-      setDetune(value);
+
+      const optionsCopy = Object.assign({}, optionsContext.options);
+      synthNum === 1
+        ? (optionsCopy.synth1.detune = value)
+        : (optionsCopy.synth2.detune = value);
+
+      optionsContext.setOptions(optionsCopy);
     },
-    [synth]
+    [synth, optionsContext, synthNum]
   );
 
   return (

--- a/src/components/OscillatorControls.tsx
+++ b/src/components/OscillatorControls.tsx
@@ -1,14 +1,25 @@
-import { useCallback, useState, memo, ChangeEvent } from "react";
+import { useCallback, useState, memo, ChangeEvent, useEffect } from "react";
 import Knob from "./Knob";
 import RadioButtonGroup from "./RadioButtonGroup";
 import { WAVEFORMS } from "../globals/constants";
 import { OscillatorControlsProps } from "../types";
 
-const OscillatorControls = ({ synthNum, synth }: OscillatorControlsProps) => {
+const OscillatorControls = ({
+  synthNum,
+  synth,
+  update,
+}: OscillatorControlsProps) => {
   const [type, setType] = useState(synth.get().oscillator.type);
   const [volume, setVolume] = useState(synth.get().volume);
   const [phase, setPhase] = useState(synth.get().oscillator.phase);
   const [detune, setDetune] = useState(synth.get().detune);
+
+  useEffect(() => {
+    setType(synth.get().oscillator.type);
+    setVolume(synth.get().volume);
+    setPhase(synth.get().oscillator.phase);
+    setDetune(synth.get().detune);
+  }, [update, synth]);
 
   const handleTypeChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {

--- a/src/components/Presets.tsx
+++ b/src/components/Presets.tsx
@@ -1,11 +1,11 @@
 import React, { useState, ChangeEvent } from "react";
 
 import { PresetsProps } from "../types";
-import { defaults, supersaw } from "../presets";
+import { defaults, supersaw, waterTemple } from "../presets";
 
 const Presets = ({ changePreset }: PresetsProps) => {
   const [selected, setSelected] = useState(defaults.name);
-  const presets = [defaults, supersaw];
+  const presets = [defaults, supersaw, waterTemple];
 
   const handleSelect = (event: ChangeEvent<HTMLSelectElement>) => {
     const name = event.target.value;

--- a/src/components/Presets.tsx
+++ b/src/components/Presets.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent } from "react";
+import { useState, ChangeEvent } from "react";
 
 import { PresetsProps } from "../types";
 import { defaults, supersaw, waterTemple, sleepy } from "../presets";

--- a/src/components/Presets.tsx
+++ b/src/components/Presets.tsx
@@ -1,11 +1,11 @@
 import React, { useState, ChangeEvent } from "react";
 
 import { PresetsProps } from "../types";
-import { defaults, supersaw, waterTemple } from "../presets";
+import { defaults, supersaw, waterTemple, sleepy } from "../presets";
 
 const Presets = ({ changePreset }: PresetsProps) => {
   const [selected, setSelected] = useState(defaults.name);
-  const presets = [defaults, supersaw, waterTemple];
+  const presets = [defaults, supersaw, waterTemple, sleepy];
 
   const handleSelect = (event: ChangeEvent<HTMLSelectElement>) => {
     const name = event.target.value;

--- a/src/components/Presets.tsx
+++ b/src/components/Presets.tsx
@@ -2,6 +2,7 @@ import { useState, ChangeEvent } from "react";
 
 import { PresetsProps } from "../types";
 import { defaults, supersaw, waterTemple, sleepy } from "../presets";
+import "../styles/Presets.css";
 
 const Presets = ({ changePreset }: PresetsProps) => {
   const [selected, setSelected] = useState(defaults.name);
@@ -16,7 +17,14 @@ const Presets = ({ changePreset }: PresetsProps) => {
 
   return (
     <div className="presets-container">
-      <select className="preset-select unselectable" onChange={handleSelect}>
+      <label className="unselectable" htmlFor="presetsSelect">
+        PRESET
+      </label>
+      <select
+        className="presets-select unselectable"
+        name="presetsSelect"
+        onChange={handleSelect}
+      >
         {presets.map((preset) => {
           return (
             <option key={preset.name} value={preset.name}>

--- a/src/components/Presets.tsx
+++ b/src/components/Presets.tsx
@@ -1,0 +1,32 @@
+import React, { useState, ChangeEvent } from "react";
+
+import { PresetsProps } from "../types";
+import { defaults, supersaw } from "../presets";
+
+const Presets = ({ changePreset }: PresetsProps) => {
+  const [selected, setSelected] = useState(defaults.name);
+  const presets = [defaults, supersaw];
+
+  const handleSelect = (event: ChangeEvent<HTMLSelectElement>) => {
+    const name = event.target.value;
+    const preset = presets.find((preset) => preset.name === name);
+    if (preset) changePreset(preset);
+    setSelected(name);
+  };
+
+  return (
+    <div className="presets-container">
+      <select className="preset-select unselectable" onChange={handleSelect}>
+        {presets.map((preset) => {
+          return (
+            <option key={preset.name} value={preset.name}>
+              {preset.name}
+            </option>
+          );
+        })}
+      </select>
+    </div>
+  );
+};
+
+export default Presets;

--- a/src/components/SynthController.tsx
+++ b/src/components/SynthController.tsx
@@ -1,4 +1,4 @@
-import { Component } from "react";
+import React, { Component } from "react";
 
 import {
   PolySynth,
@@ -15,6 +15,8 @@ import {
   Synth,
 } from "tone";
 
+import { OptionsContext } from "../contexts/OptionsContext";
+
 import OscillatorControls from "./OscillatorControls";
 import MasterControls from "./MasterControls";
 import EnvelopeControls from "./EnvelopeControls";
@@ -27,7 +29,7 @@ import Presets from "./Presets";
 
 import { KEY_TO_FULLNOTE, VALID_KEYS } from "../globals/constants";
 
-import { preset, SynthControllerState } from "../types";
+import { options, SynthControllerState } from "../types";
 
 import { defaults } from "../presets";
 
@@ -53,7 +55,7 @@ class SynthController extends Component<{}, SynthControllerState> {
       baseOctave: 3,
       notesPlaying: [],
       dragging: false,
-      toggleRerender: false,
+      options: defaults,
     };
     this.synth1 = new PolySynth(Synth, defaults.synth1);
     this.synth2 = new PolySynth(Synth, defaults.synth2);
@@ -191,7 +193,7 @@ class SynthController extends Component<{}, SynthControllerState> {
     });
   };
 
-  changePreset = (preset: preset) => {
+  changePreset = (preset: options) => {
     this.synth1.set(preset.synth1);
     this.synth2.set(preset.synth2);
     this.synth1.set({ envelope: preset.envelope });
@@ -203,7 +205,11 @@ class SynthController extends Component<{}, SynthControllerState> {
     this.distortion.set(preset.distortion);
     this.delay.set(preset.delay);
     this.bitCrusher.set(preset.bitCrusher);
-    this.setState({ toggleRerender: !this.state.toggleRerender });
+    this.setState({ options: preset });
+  };
+
+  setOptions = (options: options) => {
+    this.setState({ options: options });
   };
 
   render() {
@@ -213,51 +219,40 @@ class SynthController extends Component<{}, SynthControllerState> {
           <Midi playNote={this.playNote} stopNote={this.stopNote} />
           <Presets changePreset={this.changePreset} />
         </div>
-        <div className="top-container">
-          <OscillatorControls
-            synthNum={1}
-            synth={this.synth1}
-            update={this.state.toggleRerender}
-          />
-          <OscillatorControls
-            synthNum={2}
-            synth={this.synth2}
-            update={this.state.toggleRerender}
-          />
-          <EnvelopeControls
-            synth1={this.synth1}
-            synth2={this.synth2}
-            update={this.state.toggleRerender}
-          />
-          <FilterControls
-            filter={this.filter}
-            isPlaying={this.state.notesPlaying.length > 0}
-            fft={this.fft}
-            update={this.state.toggleRerender}
-          />
-          <EQ3Controls eq3={this.eq3} update={this.state.toggleRerender} />
-          <EffectsControls
-            reverb={this.reverb}
-            distortion={this.distortion}
-            delay={this.delay}
-            bitCrusher={this.bitCrusher}
-            update={this.state.toggleRerender}
-          />
-        </div>
-        <div className="bottom-container">
-          <MasterControls
-            masterVolume={this.masterVolume}
-            octave={this.state.baseOctave}
-            setOctave={this.setBaseOctave}
-            update={this.state.toggleRerender}
-          />
-          <Keyboard
-            notesPlaying={this.state.notesPlaying}
-            octave={this.state.baseOctave}
-            playNote={this.playNote}
-            stopNote={this.stopNote}
-          />
-        </div>
+        <OptionsContext.Provider
+          value={{ options: this.state.options, setOptions: this.setOptions }}
+        >
+          <div className="top-container">
+            <OscillatorControls synthNum={1} synth={this.synth1} />
+            <OscillatorControls synthNum={2} synth={this.synth2} />
+            <EnvelopeControls synth1={this.synth1} synth2={this.synth2} />
+            <FilterControls
+              filter={this.filter}
+              isPlaying={this.state.notesPlaying.length > 0}
+              fft={this.fft}
+            />
+            <EQ3Controls eq3={this.eq3} />
+            <EffectsControls
+              reverb={this.reverb}
+              distortion={this.distortion}
+              delay={this.delay}
+              bitCrusher={this.bitCrusher}
+            />
+          </div>
+          <div className="bottom-container">
+            <MasterControls
+              masterVolume={this.masterVolume}
+              octave={this.state.baseOctave}
+              setOctave={this.setBaseOctave}
+            />
+            <Keyboard
+              notesPlaying={this.state.notesPlaying}
+              octave={this.state.baseOctave}
+              playNote={this.playNote}
+              stopNote={this.stopNote}
+            />
+          </div>
+        </OptionsContext.Provider>
       </div>
     );
   }

--- a/src/components/SynthController.tsx
+++ b/src/components/SynthController.tsx
@@ -23,10 +23,11 @@ import Keyboard from "./Keyboard";
 import EffectsControls from "./EffectsControls";
 import EQ3Controls from "./EQ3Controls";
 import Midi from "./Midi";
+import Presets from "./Presets";
 
 import { KEY_TO_FULLNOTE, VALID_KEYS } from "../globals/constants";
 
-import { SynthControllerState } from "../types";
+import { preset, SynthControllerState } from "../types";
 
 import { defaults } from "../presets";
 
@@ -52,6 +53,7 @@ class SynthController extends Component<{}, SynthControllerState> {
       baseOctave: 3,
       notesPlaying: [],
       dragging: false,
+      toggleRerender: false,
     };
     this.synth1 = new PolySynth(Synth, defaults.synth1);
     this.synth2 = new PolySynth(Synth, defaults.synth2);
@@ -189,27 +191,57 @@ class SynthController extends Component<{}, SynthControllerState> {
     });
   };
 
+  changePreset = (preset: preset) => {
+    this.synth1.set(preset.synth1);
+    this.synth2.set(preset.synth2);
+    this.synth1.set({ envelope: preset.envelope });
+    this.synth2.set({ envelope: preset.envelope });
+    this.filter.set(preset.filter);
+    this.masterVolume.set({ volume: preset.masterVolume });
+    this.reverb.set(preset.reverb);
+    this.eq3.set(preset.eq3);
+    this.distortion.set(preset.distortion);
+    this.delay.set(preset.delay);
+    this.bitCrusher.set(preset.bitCrusher);
+    this.setState({ toggleRerender: !this.state.toggleRerender });
+  };
+
   render() {
     return (
       <div className="container">
         <div className="top-bar">
           <Midi playNote={this.playNote} stopNote={this.stopNote} />
+          <Presets changePreset={this.changePreset} />
         </div>
         <div className="top-container">
-          <OscillatorControls synthNum={1} synth={this.synth1} />
-          <OscillatorControls synthNum={2} synth={this.synth2} />
-          <EnvelopeControls synth1={this.synth1} synth2={this.synth2} />
+          <OscillatorControls
+            synthNum={1}
+            synth={this.synth1}
+            update={this.state.toggleRerender}
+          />
+          <OscillatorControls
+            synthNum={2}
+            synth={this.synth2}
+            update={this.state.toggleRerender}
+          />
+          <EnvelopeControls
+            synth1={this.synth1}
+            synth2={this.synth2}
+            update={this.state.toggleRerender}
+          />
           <FilterControls
             filter={this.filter}
             isPlaying={this.state.notesPlaying.length > 0}
             fft={this.fft}
+            update={this.state.toggleRerender}
           />
-          <EQ3Controls eq3={this.eq3} />
+          <EQ3Controls eq3={this.eq3} update={this.state.toggleRerender} />
           <EffectsControls
             reverb={this.reverb}
             distortion={this.distortion}
             delay={this.delay}
             bitCrusher={this.bitCrusher}
+            update={this.state.toggleRerender}
           />
         </div>
         <div className="bottom-container">
@@ -217,6 +249,7 @@ class SynthController extends Component<{}, SynthControllerState> {
             masterVolume={this.masterVolume}
             octave={this.state.baseOctave}
             setOctave={this.setBaseOctave}
+            update={this.state.toggleRerender}
           />
           <Keyboard
             notesPlaying={this.state.notesPlaying}

--- a/src/contexts/OptionsContext.ts
+++ b/src/contexts/OptionsContext.ts
@@ -1,0 +1,8 @@
+import React from "react";
+import { defaults } from "../presets";
+import { options } from "../types";
+
+export const OptionsContext = React.createContext({
+  options: defaults,
+  setOptions: (options: options) => {},
+});

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,7 +1,7 @@
 import { preset } from "../types";
 
 const defaults: preset = {
-  name: "defaults",
+  name: "Default",
   synth1: {
     volume: 0, // -60 - 0
     detune: 0, //-1200 - 1200
@@ -59,7 +59,7 @@ const defaults: preset = {
 };
 
 const supersaw: preset = {
-  name: "supersaw",
+  name: "Supersaw",
   synth1: {
     volume: 0,
     detune: -200,
@@ -116,4 +116,62 @@ const supersaw: preset = {
   masterVolume: 0,
 };
 
-export { defaults, supersaw };
+const waterTemple: preset = {
+  name: "Water Temple",
+  synth1: {
+    volume: 0,
+    detune: 0,
+    oscillator: {
+      type: "sine", //sine | square | triangle | sawtooth
+      phase: 0, //-180 - 180
+    },
+  },
+  synth2: {
+    volume: 0,
+    detune: 600,
+    oscillator: {
+      type: "triangle",
+      phase: 90,
+    },
+  },
+  envelope: {
+    attack: 0.01,
+    decay: 1,
+    sustain: 0.5,
+    release: 0.01,
+  },
+  filter: {
+    Q: 0,
+    frequency: 200,
+    gain: 0,
+    rolloff: -12,
+    type: "allpass",
+  },
+  reverb: {
+    decay: 20,
+    wet: 0.1,
+  },
+  eq3: {
+    low: 0,
+    mid: 0,
+    high: -6,
+    lowFrequency: 250,
+    highFrequency: 2500,
+  },
+  distortion: {
+    distortion: 0,
+    wet: 0,
+  },
+  delay: {
+    wet: 0.2,
+    delayTime: 0.2,
+    feedback: 0.4,
+  },
+  bitCrusher: {
+    wet: 0,
+    bits: 16,
+  },
+  masterVolume: 0,
+};
+
+export { defaults, supersaw, waterTemple };

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -212,7 +212,7 @@ const sleepy: preset = {
   eq3: {
     low: 0,
     mid: 0,
-    high: -6,
+    high: -60,
     lowFrequency: 250,
     highFrequency: 2500,
   },
@@ -226,8 +226,8 @@ const sleepy: preset = {
     feedback: 0.3,
   },
   bitCrusher: {
-    wet: 1,
-    bits: 8,
+    wet: 0,
+    bits: 16,
   },
   masterVolume: 0,
 };

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -174,4 +174,62 @@ const waterTemple: preset = {
   masterVolume: 0,
 };
 
-export { defaults, supersaw, waterTemple };
+const sleepy: preset = {
+  name: "Sleepy",
+  synth1: {
+    volume: 0,
+    detune: 1200,
+    oscillator: {
+      type: "square", //sine | square | triangle | sawtooth
+      phase: 0, //-180 - 180
+    },
+  },
+  synth2: {
+    volume: 0,
+    detune: -1200,
+    oscillator: {
+      type: "triangle",
+      phase: 0,
+    },
+  },
+  envelope: {
+    attack: 1,
+    decay: 1.5,
+    sustain: 1,
+    release: 5,
+  },
+  filter: {
+    Q: 0,
+    frequency: 300,
+    gain: 0,
+    rolloff: -24,
+    type: "highpass",
+  },
+  reverb: {
+    decay: 30,
+    wet: 0.05,
+  },
+  eq3: {
+    low: 0,
+    mid: 0,
+    high: -6,
+    lowFrequency: 250,
+    highFrequency: 2500,
+  },
+  distortion: {
+    distortion: 0,
+    wet: 0,
+  },
+  delay: {
+    wet: 0.3,
+    delayTime: 0.5,
+    feedback: 0.3,
+  },
+  bitCrusher: {
+    wet: 1,
+    bits: 8,
+  },
+  masterVolume: 0,
+};
+
+export { defaults, supersaw, waterTemple, sleepy };

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,6 +1,7 @@
 import { preset } from "../types";
 
 const defaults: preset = {
+  name: "defaults",
   synth1: {
     volume: 0, // -60 - 0
     detune: 0, //-1200 - 1200
@@ -57,4 +58,62 @@ const defaults: preset = {
   masterVolume: -2, // -60 - 0
 };
 
-export { defaults };
+const supersaw: preset = {
+  name: "supersaw",
+  synth1: {
+    volume: 0,
+    detune: -200,
+    oscillator: {
+      type: "sawtooth", //sine | square | triangle | sawtooth
+      phase: 0, //-180 - 180
+    },
+  },
+  synth2: {
+    volume: -10,
+    detune: 200,
+    oscillator: {
+      type: "sawtooth",
+      phase: 90,
+    },
+  },
+  envelope: {
+    attack: 0,
+    decay: 0,
+    sustain: 0.2,
+    release: 0,
+  },
+  filter: {
+    Q: 0,
+    frequency: 200,
+    gain: 0,
+    rolloff: -24,
+    type: "highpass",
+  },
+  reverb: {
+    decay: 10,
+    wet: 0.35,
+  },
+  eq3: {
+    low: 0,
+    mid: 0,
+    high: 0,
+    lowFrequency: 250,
+    highFrequency: 2500,
+  },
+  distortion: {
+    distortion: 0.5,
+    wet: 0.5,
+  },
+  delay: {
+    wet: 0,
+    delayTime: 0,
+    feedback: 0.2,
+  },
+  bitCrusher: {
+    wet: 0,
+    bits: 16,
+  },
+  masterVolume: 0,
+};
+
+export { defaults, supersaw };

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,6 +1,6 @@
-import { preset } from "../types";
+import { options } from "../types";
 
-const defaults: preset = {
+const defaults: options = {
   name: "Default",
   synth1: {
     volume: 0, // -60 - 0
@@ -58,7 +58,7 @@ const defaults: preset = {
   masterVolume: -2, // -60 - 0
 };
 
-const supersaw: preset = {
+const supersaw: options = {
   name: "Supersaw",
   synth1: {
     volume: 0,
@@ -116,7 +116,7 @@ const supersaw: preset = {
   masterVolume: 0,
 };
 
-const waterTemple: preset = {
+const waterTemple: options = {
   name: "Water Temple",
   synth1: {
     volume: 0,
@@ -174,7 +174,7 @@ const waterTemple: preset = {
   masterVolume: 0,
 };
 
-const sleepy: preset = {
+const sleepy: options = {
   name: "Sleepy",
   synth1: {
     volume: 0,

--- a/src/styles/Midi.css
+++ b/src/styles/Midi.css
@@ -8,16 +8,6 @@
   margin: 0px 5px;
 }
 
-.midi-select {
-  width: 160px;
-  border-radius: 5px;
-  border: none;
-  background-color: rgb(147, 192, 192);
-  font-family: PressStart2P;
-  font-size: 8px;
-  padding: 3px;
-}
-
 .lightbulb {
   width: 8px;
   height: 8px;

--- a/src/styles/Presets.css
+++ b/src/styles/Presets.css
@@ -1,0 +1,9 @@
+.presets-container {
+  display: flex;
+  align-items: center;
+  font-size: 12px;
+}
+
+.presets-container > label {
+  margin: 0px 5px;
+}

--- a/src/styles/SynthController.css
+++ b/src/styles/SynthController.css
@@ -8,7 +8,20 @@
 }
 
 .top-bar {
+  display: flex;
+  justify-content: space-between;
   padding: 10px 20px 0px;
+}
+
+.midi-select,
+.presets-select {
+  width: 160px;
+  border-radius: 5px;
+  border: none;
+  background-color: rgb(147, 192, 192);
+  font-family: PressStart2P;
+  font-size: 8px;
+  padding: 3px;
 }
 
 .top-container {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -47,6 +47,7 @@ type bitCrusherOptions = {
 };
 
 export type preset = {
+  name: string;
   synth1: synthOptions;
   synth2: synthOptions;
   envelope: Partial<EnvelopeOptions>;
@@ -63,6 +64,7 @@ export type SynthControllerState = {
   baseOctave: number;
   notesPlaying: string[];
   dragging: boolean;
+  toggleRerender: boolean;
 };
 
 export type ControlProps = {
@@ -78,17 +80,20 @@ export type ControlProps = {
 export type OscillatorControlsProps = {
   synthNum: 1 | 2;
   synth: PolySynth;
+  update: boolean;
 };
 
 export type EnvelopeControlsProps = {
   synth1: PolySynth;
   synth2: PolySynth;
+  update: boolean;
 };
 
 export type FilterControlsProps = {
   filter: Filter;
   isPlaying: boolean;
   fft: FFT;
+  update: boolean;
 };
 
 export type FilterDisplayProps = {
@@ -99,6 +104,7 @@ export type FilterDisplayProps = {
   gain: number;
   isPlaying: boolean;
   fft: FFT;
+  update: boolean;
 };
 
 export type EffectsControlsProps = {
@@ -106,16 +112,19 @@ export type EffectsControlsProps = {
   distortion: Distortion;
   delay: FeedbackDelay;
   bitCrusher: BitCrusher;
+  update: boolean;
 };
 
 export type EQ3ControlsProps = {
   eq3: EQ3;
+  update: boolean;
 };
 
 export type MasterControlsProps = {
   masterVolume: Volume;
   octave: number;
   setOctave: (octave: number) => void;
+  update: boolean;
 };
 
 export type KeyProps = {
@@ -152,4 +161,8 @@ export type RadioButtonGroupProps = {
 export type MidiProps = {
   playNote: (fullNote: string, startDrag?: boolean) => void;
   stopNote: (fullNote: string, stopDrag?: boolean) => void;
+};
+
+export type PresetsProps = {
+  changePreset: (preset: preset) => void;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,7 +46,7 @@ type bitCrusherOptions = {
   bits: number;
 };
 
-export type preset = {
+export type options = {
   name: string;
   synth1: synthOptions;
   synth2: synthOptions;
@@ -64,7 +64,7 @@ export type SynthControllerState = {
   baseOctave: number;
   notesPlaying: string[];
   dragging: boolean;
-  toggleRerender: boolean;
+  options: options;
 };
 
 export type ControlProps = {
@@ -80,20 +80,17 @@ export type ControlProps = {
 export type OscillatorControlsProps = {
   synthNum: 1 | 2;
   synth: PolySynth;
-  update: boolean;
 };
 
 export type EnvelopeControlsProps = {
   synth1: PolySynth;
   synth2: PolySynth;
-  update: boolean;
 };
 
 export type FilterControlsProps = {
   filter: Filter;
   isPlaying: boolean;
   fft: FFT;
-  update: boolean;
 };
 
 export type FilterDisplayProps = {
@@ -104,7 +101,6 @@ export type FilterDisplayProps = {
   gain: number;
   isPlaying: boolean;
   fft: FFT;
-  update: boolean;
 };
 
 export type EffectsControlsProps = {
@@ -112,19 +108,16 @@ export type EffectsControlsProps = {
   distortion: Distortion;
   delay: FeedbackDelay;
   bitCrusher: BitCrusher;
-  update: boolean;
 };
 
 export type EQ3ControlsProps = {
   eq3: EQ3;
-  update: boolean;
 };
 
 export type MasterControlsProps = {
   masterVolume: Volume;
   octave: number;
   setOctave: (octave: number) => void;
-  update: boolean;
 };
 
 export type KeyProps = {
@@ -164,5 +157,5 @@ export type MidiProps = {
 };
 
 export type PresetsProps = {
-  changePreset: (preset: preset) => void;
+  changePreset: (preset: options) => void;
 };


### PR DESCRIPTION
Presets which allow switching between premade settings for the synth. 

- Created Presets component in SynthController top-bar
- Added Default, Supersaw, Water Temple, and Sleepy presets
- Created Options object in SynthController state that holds state for all the pre-settable settings
- Created OptionsContext for passing/updating controls
- Controls no longer hold state

This pull only starts the feature described in #10 .

TODO:
- Allow the user to create their own presets (or edit the default ones) and save them.